### PR TITLE
Observation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -64,7 +64,6 @@ dependencies {
    testImplementation("org.testcontainers:postgresql")
    runtimeOnly("org.springframework.boot:spring-boot-docker-compose")
    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
-   implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.18.2")
    implementation("io.github.cdimascio:dotenv-java:3.2.0")
 
 
@@ -77,6 +76,8 @@ dependencies {
    testImplementation("org.mockito:mockito-junit-jupiter:4.11.0")
 
     testImplementation("com.h2database:h2:2.3.232")
+
+    implementation ("com.fasterxml.jackson.datatype:jackson-datatype-jsr310")
 }
 
 kotlin {

--- a/src/main/kotlin/com/project/byeoldori/config/JacksonConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/config/JacksonConfig.kt
@@ -1,0 +1,21 @@
+package com.project.byeoldori.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import jakarta.annotation.PostConstruct
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class JacksonConfig(
+    private val objectMapper: ObjectMapper
+) {
+    @PostConstruct
+    fun setup() {
+        // Java 8 날짜/시간 모듈 등록
+        objectMapper.registerModule(JavaTimeModule())
+
+        // Timestamp가 아닌 ISO 형식으로 직렬화
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+    }
+}

--- a/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
@@ -24,7 +24,7 @@ class SecurityConfig {
                     "/webjars/**",
                     // 이곳에 인바운드 설정을 해주어야한다. controller 작성시마다.
                     "/weather/**",
-                    "/sites/**"
+                    "/observationsites/**"
                 ).permitAll()  // Swagger URL을 허용
                 it.anyRequest().authenticated()
             }

--- a/src/main/kotlin/com/project/byeoldori/forecast/dto/ForecastResponseDTO.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/dto/ForecastResponseDTO.kt
@@ -15,7 +15,8 @@ data class UltraForecastResponseDTO(
     val wsd: Double?,
     val pty: Double?,
     val rn1: Double?,
-    val reh: Double?
+    val reh: Double?,
+    val sky: Double?
 )
 
 data class ShortForecastResponseDTO(

--- a/src/main/kotlin/com/project/byeoldori/forecast/service/ForeCastService.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/service/ForeCastService.kt
@@ -6,6 +6,9 @@ import com.project.byeoldori.forecast.dto.ShortForecastResponseDTO
 import com.project.byeoldori.forecast.utiles.RegionMapper
 import latLonToGrid
 import org.springframework.stereotype.Service
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 @Service
 class ForeCastService(
@@ -13,6 +16,9 @@ class ForeCastService(
     private val shortGridForecastService: ShortGridForecastService,
     private val midCombinedForecastService: MidCombinedForecastService
 ) {
+    // 예보 타입 정의
+    enum class ForecastType { ULTRA, SHORT, MID }
+
     fun getForecastDataByLocation(latitude: Double, longitude: Double): ForecastResponseDTO {
 
         // 1) 위경도 -> 격자x 좌표 변환
@@ -34,5 +40,95 @@ class ForeCastService(
             shortForecastResponse = shortForecast,
             midCombinedForecastDTO = midCombinedForecast
         )
+    }
+
+    // 관측 시각에 따라 예보 타입 판별
+    fun getForecastType(observationTime: LocalDateTime): ForecastType {
+        val now = LocalDateTime.now()
+        val hours = ChronoUnit.HOURS.between(now, observationTime)
+        return when {
+            hours <= 6 -> ForecastType.ULTRA
+            hours <= 72 -> ForecastType.SHORT
+            else -> ForecastType.MID
+        }
+    }
+
+    fun formatToForecastTMEF(time: LocalDateTime): String {
+        return time.format(DateTimeFormatter.ofPattern("yyyyMMddHHmm"))
+    }
+
+    // 예보 타입에 따라 sky 점수를 계산 (1: 맑음, 4: 흐림)
+    fun getSkyScoreByAllTypes(lat: Double, lon: Double, time: LocalDateTime): Double {
+        val forecast = getForecastDataByLocation(lat, lon)
+        val type = getForecastType(time)
+        val tStr = formatToForecastTMEF(time)
+
+        return when (type) {
+            ForecastType.ULTRA -> {
+                val ultra = forecast.ultraForecastResponse.find { it.tmef == tStr }
+                when (ultra?.sky?.toInt()) {
+                    1 -> 1.0; 2 -> 0.66; 3 -> 0.33; 4 -> 0.0
+                    else -> 0.5
+                }
+            }
+            ForecastType.SHORT -> {
+                val short = forecast.shortForecastResponse.find { it.tmef == tStr }
+                when (short?.sky?.toInt()) {
+                    1 -> 1.0; 2 -> 0.66; 3 -> 0.33; 4 -> 0.0
+                    else -> 0.5
+                }
+            }
+            ForecastType.MID -> {
+                val mid = forecast.midCombinedForecastDTO.find {
+                    it.tmEf.startsWith(tStr.substring(0, 8)) // 중기는 날짜 기반
+                }
+                when (mid?.sky) {
+                    "WB01" -> 1.0; "WB02" -> 0.66; "WB03" -> 0.33; "WB04" -> 0.0
+                    else -> 0.5
+                }
+            }
+        }
+    }
+
+    // 예보 타입에 따라 강수 점수를 계산 (0: 강수 없음 → 1.0점)
+    fun getPreScoreByAllTypes(lat: Double, lon: Double, time: LocalDateTime): Double {
+        val forecast = getForecastDataByLocation(lat, lon)
+        val type = getForecastType(time)
+        val tStr = formatToForecastTMEF(time)
+
+        return when (type) {
+            ForecastType.ULTRA -> {
+                val ultra = forecast.ultraForecastResponse.find { it.tmef == tStr }
+                if ((ultra?.pty ?: 0.0) == 0.0) 1.0 else 0.0
+            }
+            ForecastType.SHORT -> {
+                val short = forecast.shortForecastResponse.find { it.tmef == tStr }
+                if ((short?.pty ?: 0.0) == 0.0) 1.0 else 0.0
+            }
+            ForecastType.MID -> {
+                val mid = forecast.midCombinedForecastDTO.find {
+                    it.tmEf.startsWith(tStr.substring(0, 8))
+                }
+                if ((mid?.pre ?: "WB00") == "WB00") 1.0 else 0.0
+            }
+        }
+    }
+
+    // 예보 타입에 따라 풍속 점수를 계산 (풍속 낮을수록 점수 높음), 중기는 고려하지 않음
+    fun getWindScoreByAllTypes(lat: Double, lon: Double, time: LocalDateTime): Double? {
+        val forecast = getForecastDataByLocation(lat, lon)
+        val type = getForecastType(time)
+        val tStr = formatToForecastTMEF(time)
+
+        val wsd = when (type) {
+            ForecastType.ULTRA -> forecast.ultraForecastResponse.find { it.tmef == tStr }?.wsd
+            ForecastType.SHORT -> forecast.shortForecastResponse.find { it.tmef == tStr }?.wsd
+            ForecastType.MID -> null // 중기는 풍속 정보 없음
+        }
+
+        return wsd?.let {
+            val decayFactor = 5.0 // 기준 풍속을 정해야함
+            1.0 / (1.0 + (it / decayFactor)) // 풍속이 높을수록 점수는 줄어듦
+        }
     }
 }

--- a/src/main/kotlin/com/project/byeoldori/observationsites/controller/ObservationSiteController.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/controller/ObservationSiteController.kt
@@ -1,8 +1,8 @@
-package com.project.byeoldori.observation.controller
+package com.project.byeoldori.observationsites.controller
 
-import com.project.byeoldori.observation.dto.ObservationSiteDto
-import com.project.byeoldori.observation.entity.ObservationSite
-import com.project.byeoldori.observation.service.ObservationSiteService
+import com.project.byeoldori.observationsites.dto.ObservationSiteDto
+import com.project.byeoldori.observationsites.entity.ObservationSite
+import com.project.byeoldori.observationsites.service.ObservationSiteService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*
 
 @Tag(name = "Observation Site", description = "관측지 API")
 @RestController
-@RequestMapping("/sites")
+@RequestMapping("/observationsites")
 class ObservationSiteController(
     private val siteService: ObservationSiteService
 ) {

--- a/src/main/kotlin/com/project/byeoldori/observationsites/controller/ObservationSiteController.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/controller/ObservationSiteController.kt
@@ -1,7 +1,10 @@
 package com.project.byeoldori.observationsites.controller
 
 import com.project.byeoldori.observationsites.dto.ObservationSiteDto
+import com.project.byeoldori.observationsites.dto.ObservationSiteResponseDto
+import com.project.byeoldori.observationsites.dto.RecommendationRequestDto
 import com.project.byeoldori.observationsites.entity.ObservationSite
+import com.project.byeoldori.observationsites.service.ObservationSiteRecommendationService
 import com.project.byeoldori.observationsites.service.ObservationSiteService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.tags.Tag
@@ -13,7 +16,8 @@ import org.springframework.web.bind.annotation.*
 @RestController
 @RequestMapping("/observationsites")
 class ObservationSiteController(
-    private val siteService: ObservationSiteService
+    private val siteService: ObservationSiteService,
+    private val siteRecommendationService: ObservationSiteRecommendationService
 ) {
     @Operation(summary = "관측지 등록", description = "새로운 관측지 정보를 등록합니다.")
     @PostMapping
@@ -48,5 +52,16 @@ class ObservationSiteController(
     fun deleteByName(@PathVariable name: String): ResponseEntity<Void> {
         siteService.deleteSiteByName(name)
         return ResponseEntity.noContent().build()
+    }
+
+    @Operation(summary = "관측지 추천", description = "점수가 높은 상위 5개의 관측지를 추천합니다.")
+    @PostMapping("/recommend")
+    fun recommendSites(@RequestBody @Valid request: RecommendationRequestDto): ResponseEntity<List<ObservationSiteResponseDto>> {
+        val recommendedSites = siteRecommendationService.recommendSites(
+            userLat = request.userLat,
+            userLon = request.userLon,
+            observationTime = request.observationTime
+        )
+        return ResponseEntity.ok(recommendedSites)
     }
 }

--- a/src/main/kotlin/com/project/byeoldori/observationsites/dto/ObservationSiteDto.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/dto/ObservationSiteDto.kt
@@ -2,7 +2,10 @@ package com.project.byeoldori.observationsites.dto
 
 import com.project.byeoldori.observationsites.entity.ObservationSite
 import io.swagger.v3.oas.annotations.media.Schema
+import org.springframework.format.annotation.DateTimeFormat
+import java.time.LocalDateTime
 
+// 관측지 CRUD
 data class ObservationSiteDto(
     @Schema(description = "관측지 이름", example = "별마로 천문대")
     val name: String,
@@ -11,9 +14,26 @@ data class ObservationSiteDto(
     val latitude: Double,
 
     @Schema(description = "위도", example = "37.1978774787")
-    val longitude: Double
+    val longitude: Double,
 )
 
+// 관측지 추천 응답용 DTO
+data class ObservationSiteResponseDto(
+    val name: String,
+    val latitude: Double,
+    val longitude: Double,
+    val score: Double
+)
+
+// 관측지 추천 입력 DTO
+data class RecommendationRequestDto(
+    val userLat: Double,
+    val userLon: Double,
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    val observationTime: LocalDateTime
+)
+
+// DTO ➔ Entity 변환
 fun ObservationSiteDto.toEntity(): ObservationSite {
     return ObservationSite(
         name = this.name,
@@ -22,4 +42,12 @@ fun ObservationSiteDto.toEntity(): ObservationSite {
     )
 }
 
-
+// Entity ➔ DTO 변환
+fun ObservationSite.toDto(score: Double): ObservationSiteResponseDto {
+    return ObservationSiteResponseDto(
+        name = this.name,
+        latitude = this.latitude,
+        longitude = this.longitude,
+        score = score
+    )
+}

--- a/src/main/kotlin/com/project/byeoldori/observationsites/dto/ObservationSiteDto.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/dto/ObservationSiteDto.kt
@@ -1,6 +1,6 @@
-package com.project.byeoldori.observation.dto
+package com.project.byeoldori.observationsites.dto
 
-import com.project.byeoldori.observation.entity.ObservationSite
+import com.project.byeoldori.observationsites.entity.ObservationSite
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class ObservationSiteDto(

--- a/src/main/kotlin/com/project/byeoldori/observationsites/entity/ObservationSite.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/entity/ObservationSite.kt
@@ -1,4 +1,4 @@
-package com.project.byeoldori.observation.entity
+package com.project.byeoldori.observationsites.entity
 
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue

--- a/src/main/kotlin/com/project/byeoldori/observationsites/repository/ObservationSiteRepository.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/repository/ObservationSiteRepository.kt
@@ -1,6 +1,6 @@
-package com.project.byeoldori.observation.repository
+package com.project.byeoldori.observationsites.repository
 
-import com.project.byeoldori.observation.entity.ObservationSite
+import com.project.byeoldori.observationsites.entity.ObservationSite
 import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.JpaRepository
 

--- a/src/main/kotlin/com/project/byeoldori/observationsites/service/ObservationSiteRecommendationService.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/service/ObservationSiteRecommendationService.kt
@@ -1,0 +1,115 @@
+package com.project.byeoldori.observationsites.service
+
+import com.project.byeoldori.forecast.service.ForeCastService
+import com.project.byeoldori.observationsites.dto.ObservationSiteResponseDto
+import com.project.byeoldori.observationsites.dto.toDto
+import com.project.byeoldori.observationsites.repository.ObservationSiteRepository
+import org.springframework.stereotype.Service
+import java.time.*
+import kotlin.math.*
+
+@Service
+class ObservationSiteRecommendationService(
+    // 이미 구현된 ForecastService를 주입받아 날씨 점수 계산에 사용
+    private val observationSiteRepository: ObservationSiteRepository,
+    private val forecastService: ForeCastService
+) {
+    // 예보 종류 구분
+    enum class ForecastType { ULTRA, SHORT, MID }
+
+    // 관측 시각에 따라 가장 적절한 예보 데이터를 사용하여 관측지 추천 리스트 반환
+    fun recommendSites(userLat: Double, userLon: Double, observationTime: LocalDateTime): List<ObservationSiteResponseDto> {
+        val sites = observationSiteRepository.findAll()
+
+        return sites.map { site ->
+            val type = getForecastType(observationTime)
+
+            // 예보 기반 점수 추출
+            val sky = forecastService.getSkyScoreByAllTypes(site.latitude, site.longitude, observationTime)
+            val pty = forecastService.getPreScoreByAllTypes(site.latitude, site.longitude, observationTime)
+            val wind = forecastService.getWindScoreByAllTypes(site.latitude, site.longitude, observationTime)
+
+            // 중기 예보일 경우 달/광공해 점수 제외
+            val moon = if (type == ForecastType.MID) null else getMoonPhaseScore(observationTime)
+            val light = if (type == ForecastType.MID) null else getLightPollutionScore(site.latitude, site.longitude)
+
+            // 점수 계산
+            val score = calculateTotalScore(type, sky, pty, wind, moon, light)
+            Pair(site, score)
+        }
+            .sortedByDescending { it.second } // 높은 점수순 정렬
+            .take(5) // 상위 5개만 반환
+            .map { (site, score) -> site.toDto(score)}
+    }
+
+    // 관측 시간으로부터 예보 타입 결정
+    fun getForecastType(observationTime: LocalDateTime): ForecastType {
+        val now = LocalDateTime.now()
+        val hours = Duration.between(now, observationTime).toHours()
+        return when {
+            hours <= 6 -> ForecastType.ULTRA
+            hours <= 72 -> ForecastType.SHORT
+            else -> ForecastType.MID
+        }
+    }
+
+    // 달의 위상 점수 계산
+    fun getMoonPhaseScore(observationTime: LocalDateTime): Double {
+        val knownNewMoon = LocalDateTime.of(2000, 1, 6, 18, 14)
+        val moonCycle = 29.53058867
+
+        // 관측 시각과 기준 시각 간의 차이를 밀리초 단위로 계산한 후 일수로 환산
+        val diffInMillis = observationTime.toInstant(ZoneOffset.UTC).toEpochMilli() -
+                knownNewMoon.toInstant(ZoneOffset.UTC).toEpochMilli()
+        val diffInDays = diffInMillis.toDouble() / (1000 * 60 * 60 * 24)
+
+        // 달의 주기로 나눈 나머지를 구하여 현재 위상(phase)을 계산 (음수 보정 포함)
+        val phase = ((diffInDays % moonCycle) + moonCycle) % moonCycle
+        // 0~1 사이로 정규화 (0 또는 1: 초승당, 그믐달, 0.5: 보름달)
+        val normalized = phase / moonCycle
+
+        // sine 함수를 사용하여 관측 적합도 점수를 매핑:
+        // normalized = 0 또는 1일 때 (초승달, 그믐달) sin(0)=0, sin(π)=0 → score=1,
+        // normalized = 0.5 (보름달)일 때 sin(π/2)=1 → score=0
+        return 1 - sin(Math.PI * normalized)
+    }
+
+    // 광공해 값 → 점수로 변환 (어두울수록 높음)
+    fun getLightPollutionScore(lat: Double, lon: Double): Double {
+        val value = queryLightPollutionValue(lat, lon)
+        return when { // 점수 조정 필요
+            value < 1.0 -> 1.0
+            value < 3.0 -> 0.8
+            value < 6.0 -> 0.6
+            value < 12.0 -> 0.4
+            value < 20.0 -> 0.2
+            else -> 0.0
+        }
+    }
+
+    // TODO: 실제 광공해 데이터 연동 필요
+    fun queryLightPollutionValue(lat: Double, lon: Double): Double {
+        return 6.0 // 임시 값
+    }
+
+    // 예보 타입별로 점수 항목 및 가중치 다르게 계산
+    fun calculateTotalScore(
+        type: ForecastType,
+        sky: Double,
+        pty: Double,
+        wind: Double?,
+        moon: Double?,
+        lightPollution: Double?
+    ): Double {
+        return when (type) {
+            ForecastType.MID -> (0.5714 * sky) + (0.4286 * pty) // 40:30 비중 정규화
+            else -> {
+                val w = wind ?: 0.5
+                val m = moon ?: 0.5
+                val l = lightPollution ?: 0.5
+                (0.40 * sky) + (0.30 * pty) + (0.05 * w) + (0.15 * m) + (0.10 * l)
+            }
+        }
+    }
+}
+

--- a/src/main/kotlin/com/project/byeoldori/observationsites/service/ObservationSiteService.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/service/ObservationSiteService.kt
@@ -1,9 +1,9 @@
-package com.project.byeoldori.observation.service
+package com.project.byeoldori.observationsites.service
 
-import com.project.byeoldori.observation.dto.ObservationSiteDto
-import com.project.byeoldori.observation.dto.toEntity
-import com.project.byeoldori.observation.entity.ObservationSite
-import com.project.byeoldori.observation.repository.ObservationSiteRepository
+import com.project.byeoldori.observationsites.dto.ObservationSiteDto
+import com.project.byeoldori.observationsites.dto.toEntity
+import com.project.byeoldori.observationsites.entity.ObservationSite
+import com.project.byeoldori.observationsites.repository.ObservationSiteRepository
 import org.springframework.stereotype.Service
 
 @Service

--- a/src/test/kotlin/com/project/byeoldori/controller/ObservationSiteControllerTest.kt
+++ b/src/test/kotlin/com/project/byeoldori/controller/ObservationSiteControllerTest.kt
@@ -3,7 +3,9 @@ package com.project.byeoldori.controller
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.project.byeoldori.observationsites.controller.ObservationSiteController
 import com.project.byeoldori.observationsites.dto.ObservationSiteDto
+import com.project.byeoldori.observationsites.dto.RecommendationRequestDto
 import com.project.byeoldori.observationsites.entity.ObservationSite
+import com.project.byeoldori.observationsites.service.ObservationSiteRecommendationService
 import com.project.byeoldori.observationsites.service.ObservationSiteService
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.BeforeEach
@@ -17,21 +19,32 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import java.time.LocalDateTime
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.project.byeoldori.observationsites.dto.ObservationSiteResponseDto
+
+private val objectMapper: ObjectMapper = ObjectMapper().apply {
+    registerModule(JavaTimeModule())
+    disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+}
 
 @ExtendWith(MockitoExtension::class)
 class ObservationSiteControllerTest {
 
     @Mock
     private lateinit var siteService: ObservationSiteService
+    @Mock
+    private lateinit var siteRecommendationService: ObservationSiteRecommendationService
     private lateinit var controller: ObservationSiteController
     private lateinit var mockMvc: MockMvc
-    private val objectMapper = ObjectMapper()
 
     @BeforeEach
     fun setup() {
-        controller = ObservationSiteController(siteService)
+        controller = ObservationSiteController(siteService, siteRecommendationService)
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build()
     }
+
     @Test
     fun `관측지 등록`() {
         val dto = ObservationSiteDto("백두산", 41.985, 128.081)
@@ -96,5 +109,39 @@ class ObservationSiteControllerTest {
 
         mockMvc.perform(delete("/observationsites/지리산"))
             .andExpect(status().isNoContent)
+    }
+
+    @Test
+    fun `관측지 추천`() {
+        val sampleRecommendation = listOf(
+            ObservationSiteResponseDto("별마로 천문대", 37.197877, 128.486595, 0.85),
+            ObservationSiteResponseDto("충북대학교", 37.5, 127.5, 0.65)
+        )
+
+        val request = RecommendationRequestDto(
+            userLat = 37.5665,
+            userLon = 126.9780,
+            observationTime = LocalDateTime.of(2025, 4, 29, 21, 0)
+        )
+
+        `when`(
+            siteRecommendationService.recommendSites(
+                userLat = request.userLat,
+                userLon = request.userLon,
+                observationTime = request.observationTime
+            )
+        ).thenReturn(sampleRecommendation)
+
+        mockMvc.perform(
+            post("/observationsites/recommend")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request))
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.size()", `is`(2)))
+            .andExpect(jsonPath("$[0].name", `is`("별마로 천문대")))
+            .andExpect(jsonPath("$[0].score", `is`(0.85)))
+            .andExpect(jsonPath("$[1].name", `is`("충북대학교")))
+            .andExpect(jsonPath("$[1].score", `is`(0.65)))
     }
 }

--- a/src/test/kotlin/com/project/byeoldori/controller/ObservationSiteControllerTest.kt
+++ b/src/test/kotlin/com/project/byeoldori/controller/ObservationSiteControllerTest.kt
@@ -1,10 +1,10 @@
 package com.project.byeoldori.controller
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.project.byeoldori.observation.controller.ObservationSiteController
-import com.project.byeoldori.observation.dto.ObservationSiteDto
-import com.project.byeoldori.observation.entity.ObservationSite
-import com.project.byeoldori.observation.service.ObservationSiteService
+import com.project.byeoldori.observationsites.controller.ObservationSiteController
+import com.project.byeoldori.observationsites.dto.ObservationSiteDto
+import com.project.byeoldori.observationsites.entity.ObservationSite
+import com.project.byeoldori.observationsites.service.ObservationSiteService
 import org.hamcrest.Matchers.*
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -35,12 +35,12 @@ class ObservationSiteControllerTest {
     @Test
     fun `관측지 등록`() {
         val dto = ObservationSiteDto("백두산", 41.985, 128.081)
-        val response = ObservationSite(1L, "백두산", 41.985, 128.081)
+        val response = ObservationSite(1, "백두산", 41.985, 128.081)
 
         `when`(siteService.createObservationSite(dto)).thenReturn(response)
 
         mockMvc.perform(
-            post("/sites")
+            post("/observationsites")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dto))
         )
@@ -51,38 +51,38 @@ class ObservationSiteControllerTest {
     @Test
     fun `모든 관측지 조회`() {
         val list = listOf(
-            ObservationSite(1L, "백두산", 41.0, 128.0),
-            ObservationSite(2L, "한라산", 33.0, 126.0)
+            ObservationSite(1, "백두산", 41.0, 128.0),
+            ObservationSite(2, "한라산", 33.0, 126.0)
         )
 
         `when`(siteService.getAllSites()).thenReturn(list)
 
-        mockMvc.perform(get("/sites"))
+        mockMvc.perform(get("/observationsites"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.size()", `is`(2)))
             .andExpect(jsonPath("$[0].name", `is`("백두산")))
     }
 
     @Test
-    fun `관측지 이름으로 검색`() {
-        val list = listOf(ObservationSite(1L, "백두산", 41.0, 128.0))
+    fun `키워드로 관측지 검색`() {
+        val list = listOf(ObservationSite(1, "백두산", 41.0, 128.0))
 
         `when`(siteService.searchByName("백")).thenReturn(list)
 
-        mockMvc.perform(get("/sites/name").param("keyword", "백"))
+        mockMvc.perform(get("/observationsites/name").param("keyword", "백"))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$[0].name", `is`("백두산")))
     }
 
     @Test
-    fun `관측지 이름 기준 수정`() {
+    fun `관측지 수정`() {
         val dto = ObservationSiteDto("한라산", 33.0, 126.0)
-        val updated = ObservationSite(2L, "한라산", 33.0, 126.0)
+        val updated = ObservationSite(2, "한라산", 33.0, 126.0)
 
         `when`(siteService.updateSiteByName("지리산", dto)).thenReturn(updated)
 
         mockMvc.perform(
-            put("/sites/name/지리산")
+            put("/observationsites/지리산")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(dto))
         )
@@ -94,7 +94,7 @@ class ObservationSiteControllerTest {
     fun `관측지 삭제`() {
         doNothing().`when`(siteService).deleteSiteByName("지리산")
 
-        mockMvc.perform(delete("/sites/name/지리산"))
+        mockMvc.perform(delete("/observationsites/지리산"))
             .andExpect(status().isNoContent)
     }
 }


### PR DESCRIPTION
1. 단어 명확화
- observation -> observationsites 명확화

2. 기존 코드 수정
- gradle에서 중복 의존성 제거, localdatetime 의존성 추가
- 초단기 예보 하늘상태(sky) 빠져있던거 추가
- 날씨 직렬화 Config 작성

3. 관측지 관측 적합도 알고리즘 구현
- 3일 이내는 하늘상태, 강수유무, 풍속, 달의위상, 광공해 고려
- 3일 이상일경우 하늘상태, 강수유무만 고려
- 테스트 코드 작성
- 달의 위상은 함수로 계산
- 광공해 수치는 데이터 반영 아직 안했고, 정규화 점수도 재설정해야함.