### PR TITLE
Observation - 관측지(장소) 즐겨찾기 기능 수정

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/observationsites/controller/UserSavedSiteController.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/controller/UserSavedSiteController.kt
@@ -1,7 +1,7 @@
 package com.project.byeoldori.observationsites.controller
 
 import com.project.byeoldori.common.web.ApiResponse
-import com.project.byeoldori.observationsites.dto.ObservationSiteDto
+import com.project.byeoldori.observationsites.dto.*
 import com.project.byeoldori.observationsites.service.UserSavedSiteService
 import com.project.byeoldori.user.entity.User
 import io.swagger.v3.oas.annotations.Operation
@@ -18,28 +18,39 @@ class UserSavedSiteController(
 
     @Operation(summary = "저장된 관측지 조회", description = "사용자가 저장한 관측지 목록을 조회합니다.")
     @GetMapping
-    fun getSavedSites(@RequestAttribute("currentUser") user: User): ResponseEntity<List<ObservationSiteDto>> {
+    fun getSavedSites(@RequestAttribute("currentUser") user: User): ResponseEntity<List<SavedSiteResponseDto>> {
         val savedSites = userSavedSiteService.getSavedSites(user)
         return ResponseEntity.ok(savedSites)
     }
 
-    @Operation(summary = "관측지 저장", description = "관측지를 사용자 즐겨찾기로 저장합니다.")
-    @PostMapping("/{siteId}")
-    fun saveSite(
+    @Operation(summary = "즐겨찾기 토글", description = "즐겨찾기 상태를 추가 또는 삭제로 전환합니다." +
+            "저장된 관측지 즐겨찾기 할 경우 siteId만 입력, 임의 장소 즐겨찾기 할 경우 name, lat, lon 3개만 입력")
+    @PostMapping("/toggle")
+    fun toggleSavedSite(
         @RequestAttribute("currentUser") user: User,
-        @PathVariable siteId: Long
-    ): ResponseEntity<ApiResponse<Unit>> {
-        userSavedSiteService.saveSite(user, siteId)
-        return ResponseEntity.ok(ApiResponse.ok("관측지가 저장되었습니다."))
+        @RequestBody request: SiteToggleRequest
+    ): ResponseEntity<ApiResponse<SiteToggleResponse>> {
+        val response = userSavedSiteService.toggleSite(user, request)
+        return ResponseEntity.ok(ApiResponse.ok(response))
+    }
+
+    @Operation(summary = "저장된 관측지 상세 조회", description = "즐겨찾기한 장소의 정보를 상세 조회합니다.")
+    @GetMapping("/{savedSiteId}")
+    fun getSavedSiteDetail(
+        @RequestAttribute("currentUser") user: User,
+        @PathVariable savedSiteId: Long
+    ): ResponseEntity<SavedSiteResponseDto> {
+        val savedSite = userSavedSiteService.getSavedSiteDetail(user, savedSiteId)
+        return ResponseEntity.ok(savedSite)
     }
 
     @Operation(summary = "관측지 즐겨찾기 삭제", description = "사용자가 저장한 관측지를 즐겨찾기 목록에서 삭제합니다.")
-    @DeleteMapping("/{siteId}")
+    @DeleteMapping("/{savedSiteId}")
     fun deleteSavedSite(
         @RequestAttribute("currentUser") user: User,
-        @PathVariable siteId: Long
+        @PathVariable savedSiteId: Long
     ): ResponseEntity<ApiResponse<Unit>> {
-        userSavedSiteService.deleteSite(user, siteId)
-        return ResponseEntity.ok(ApiResponse.ok("관측지가 즐겨찾기에서 삭제되었습니다."))
+        userSavedSiteService.deleteSavedSite(user, savedSiteId)
+        return ResponseEntity.ok(ApiResponse.ok("즐겨찾기에서 삭제되었습니다."))
     }
 }

--- a/src/main/kotlin/com/project/byeoldori/observationsites/dto/ObservationSiteDto.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/dto/ObservationSiteDto.kt
@@ -2,8 +2,6 @@ package com.project.byeoldori.observationsites.dto
 
 import com.project.byeoldori.observationsites.entity.ObservationSite
 import io.swagger.v3.oas.annotations.media.Schema
-import org.springframework.format.annotation.DateTimeFormat
-import java.time.LocalDateTime
 
 // 관측지 CRUD
 data class ObservationSiteDto(
@@ -17,22 +15,6 @@ data class ObservationSiteDto(
     val longitude: Double,
 )
 
-// 관측지 추천 응답용 DTO
-data class ObservationSiteResponseDto(
-    val name: String,
-    val latitude: Double,
-    val longitude: Double,
-    val score: Double
-)
-
-// 관측지 추천 입력 DTO
-data class RecommendationRequestDto(
-    val userLat: Double,
-    val userLon: Double,
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
-    val observationTime: LocalDateTime
-)
-
 // 관측지 상세 정보 DTO
 data class ObservationSiteDetailDto(
     val id: Long,
@@ -44,6 +26,39 @@ data class ObservationSiteDetailDto(
     val averageScore: Double
 )
 
+@Schema(description = "즐겨찾기 토글 요청 DTO")
+data class SiteToggleRequest(
+    @Schema(description = "관측지 ID 저장된 관측지 토글 시 사용")
+    val siteId: Long? = null,
+
+    @Schema(description = "사용자 지정 장소 즐겨찾기(임의 장소 즐겨찾기 시)", example = "저장된 관측지가 아니고 임의의 장소 즐겨찾기시" +
+            " name, lat, lon 입력")
+    val name: String? = null,
+
+    @Schema(description = "위도(임의 장소 즐겨찾기 시)")
+    val latitude: Double? = null,
+
+    @Schema(description = "경도 (임의 장소 즐겨찾기 시)")
+    val longitude: Double? = null
+)
+
+@Schema(description = "즐겨찾기 토글 응답 DTO")
+data class SiteToggleResponse(
+    @Schema(description = "최종 즐겨찾기 상태 (true: 추가됨, false: 삭제됨)")
+    val isSaved: Boolean,
+    @Schema(description = "즐겨찾기 항목의 고유 ID (추가된 경우에만 반환됨)")
+    val savedSiteId: Long?
+)
+
+data class SavedSiteResponseDto(
+    val savedSiteId: Long, // 즐겨찾기 항목 자체의 ID
+    val siteId: Long?,     // 공식 관측지의 ID
+    val name: String,
+    val latitude: Double,
+    val longitude: Double,
+    val isCustom: Boolean // 공식(false) / 개인(true)
+)
+
 // DTO ➔ Entity 변환
 fun ObservationSiteDto.toEntity(): ObservationSite {
     return ObservationSite(
@@ -52,19 +67,3 @@ fun ObservationSiteDto.toEntity(): ObservationSite {
         longitude = this.longitude
     )
 }
-
-// Entity ➔ DTO 변환 (score 포함)
-fun ObservationSite.toDto(score: Double): ObservationSiteResponseDto {
-    return ObservationSiteResponseDto(
-        name = this.name,
-        latitude = this.latitude,
-        longitude = this.longitude,
-        score = score
-    )
-}
-
-fun ObservationSite.toSimpleDto() = ObservationSiteDto(
-    name = this.name,
-    latitude = this.latitude,
-    longitude = this.longitude
-)

--- a/src/main/kotlin/com/project/byeoldori/observationsites/entity/UserSavedSite.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/entity/UserSavedSite.kt
@@ -2,26 +2,32 @@ package com.project.byeoldori.observationsites.entity
 
 import com.project.byeoldori.user.entity.User
 import jakarta.persistence.*
-import java.io.Serializable
 import java.time.LocalDateTime
 
 @Entity
 @Table(name = "user_saved_sites")
-@IdClass(UserSavedSiteId::class)
 class UserSavedSite(
-    @Id
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     val user: User,
 
-    @Id
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "site_id")
-    val site: ObservationSite,
+    val site: ObservationSite? = null,
+
+    // 사용자가 임의의 장소 즐겨찾기
+    @Column(name = "custom_name")
+    var customName: String? = null,
+
+    @Column(name = "custom_latitude")
+    var customLatitude: Double? = null,
+
+    @Column(name = "custom_longitude")
+    var customLongitude: Double? = null,
+
     val savedAt: LocalDateTime = LocalDateTime.now()
 )
-
-data class UserSavedSiteId(
-    var user: Long = 0L,
-    var site: Long = 0L
-) : Serializable

--- a/src/main/kotlin/com/project/byeoldori/observationsites/repository/UserSavedSiteRepository.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/repository/UserSavedSiteRepository.kt
@@ -2,13 +2,20 @@ package com.project.byeoldori.observationsites.repository
 
 import com.project.byeoldori.observationsites.entity.ObservationSite
 import com.project.byeoldori.observationsites.entity.UserSavedSite
-import com.project.byeoldori.observationsites.entity.UserSavedSiteId
 import com.project.byeoldori.user.entity.User
 import org.springframework.data.jpa.repository.JpaRepository
+import java.util.*
 
-interface UserSavedSiteRepository : JpaRepository<UserSavedSite, UserSavedSiteId> {
+interface UserSavedSiteRepository : JpaRepository<UserSavedSite, Long> {
     fun findAllByUser(user: User): List<UserSavedSite>
+
     fun existsByUserAndSite(user: User, site: ObservationSite): Boolean
-    fun findByUserAndSite(user: User, site: ObservationSite): UserSavedSite?
-    fun deleteBySiteId(siteId: Long)
+
+    fun findByIdAndUser(id: Long, user: User): Optional<UserSavedSite>
+
+    fun findByUserAndSite(user: User, site: ObservationSite): Optional<UserSavedSite>
+
+    fun findByUserAndCustomLatitudeAndCustomLongitude(user: User, latitude: Double, longitude: Double): Optional<UserSavedSite>
+
+    fun deleteAllBySite_Id(siteId: Long)
 }

--- a/src/main/kotlin/com/project/byeoldori/observationsites/service/ObservationSiteService.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/service/ObservationSiteService.kt
@@ -73,7 +73,7 @@ class ObservationSiteService(
     @Transactional
     fun deleteSiteById(id: Long): Boolean {
         if (!observationSiteRepository.existsById(id)) return false
-        userSavedSiteRepository.deleteBySiteId(id)   // 즐겨찾기 정리
+        userSavedSiteRepository.deleteAllBySite_Id(id)
         observationSiteRepository.deleteById(id)
         return true
     }

--- a/src/main/kotlin/com/project/byeoldori/observationsites/service/UserSavedSiteService.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/service/UserSavedSiteService.kt
@@ -1,7 +1,6 @@
 package com.project.byeoldori.observationsites.service
 
-import com.project.byeoldori.observationsites.dto.ObservationSiteDto
-import com.project.byeoldori.observationsites.dto.toSimpleDto
+import com.project.byeoldori.observationsites.dto.*
 import com.project.byeoldori.observationsites.entity.UserSavedSite
 import com.project.byeoldori.observationsites.repository.ObservationSiteRepository
 import com.project.byeoldori.observationsites.repository.UserSavedSiteRepository
@@ -17,34 +16,95 @@ class UserSavedSiteService(
     private val siteRepo: ObservationSiteRepository
 ) {
 
-    // 추천된 관측지를 사용자 저장 목록에 추가
-    @Transactional
-    fun saveSite(user: User, siteId: Long) {
-        val site = siteRepo.findById(siteId).orElseThrow {
-            ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 관측지입니다.")
+    fun toggleSite(user: User, request: SiteToggleRequest): SiteToggleResponse {
+        // 저장된 관측지(siteId) 토글
+        if (request.siteId != null) {
+            val site = siteRepo.findById(request.siteId).orElseThrow {
+                ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 관측지입니다.")
+            }
+            val savedSiteOpt = savedSiteRepo.findByUserAndSite(user, site)
+
+            return if (savedSiteOpt.isPresent) {
+                // 이미 즐겨찾기 상태 -> 삭제
+                savedSiteRepo.delete(savedSiteOpt.get())
+                SiteToggleResponse(isSaved = false, savedSiteId = null)
+            } else {
+                // 즐겨찾기 아닌 상태 -> 추가
+                val newSavedSite = savedSiteRepo.save(UserSavedSite(user = user, site = site))
+                SiteToggleResponse(isSaved = true, savedSiteId = newSavedSite.id)
+            }
         }
-        if (savedSiteRepo.existsByUserAndSite(user, site)) {
-            throw ResponseStatusException(HttpStatus.CONFLICT, "이미 저장된 관측지입니다.")
+        // 임의 장소(좌표) 토글
+        else if (request.latitude != null && request.longitude != null) {
+            val savedSiteOpt = savedSiteRepo.findByUserAndCustomLatitudeAndCustomLongitude(user, request.latitude, request.longitude)
+
+            return if (savedSiteOpt.isPresent) {
+                // 이미 즐겨찾기 상태 -> 삭제
+                savedSiteRepo.delete(savedSiteOpt.get())
+                SiteToggleResponse(isSaved = false, savedSiteId = null)
+            } else {
+                // 즐겨찾기 아닌 상태 -> 추가
+                val newCustomSite = UserSavedSite(
+                    user = user,
+                    customName = request.name ?: "이름 없는 장소",
+                    customLatitude = request.latitude,
+                    customLongitude = request.longitude
+                )
+                val newSavedSite = savedSiteRepo.save(newCustomSite)
+                SiteToggleResponse(isSaved = true, savedSiteId = newSavedSite.id)
+            }
         }
-        savedSiteRepo.save(UserSavedSite(user = user, site = site))
+        // 요청 정보가 잘못된 경우
+        else {
+            throw ResponseStatusException(HttpStatus.BAD_REQUEST, "관측지 ID 또는 좌표 정보가 필요합니다.")
+        }
     }
 
     // 저장된 관측지 정보를 반환
     @Transactional(readOnly = true)
-    fun getSavedSites(user: User): List<ObservationSiteDto> {
-        return savedSiteRepo.findAllByUser(user).map { it.site.toSimpleDto() }
+    fun getSavedSites(user: User): List<SavedSiteResponseDto> {
+        return savedSiteRepo.findAllByUser(user).map { it.toDto() }
+    }
+
+    // 즐겨찾기 장소 상세 조회
+    @Transactional(readOnly = true)
+    fun getSavedSiteDetail(user: User, savedSiteId: Long): SavedSiteResponseDto {
+        val savedSite = savedSiteRepo.findByIdAndUser(savedSiteId, user).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "즐겨찾기 목록에 없는 항목이거나 권한이 없습니다.")
+        }
+        return savedSite.toDto()
     }
 
     // 즐겨찾기에 저장된 관측지 삭제
-    fun deleteSite(user: User, siteId: Long) {
-        val site = siteRepo.findById(siteId).orElseThrow {
-            ResponseStatusException(HttpStatus.NOT_FOUND, "존재하지 않는 관측지입니다.")
+    @Transactional
+    fun deleteSavedSite(user: User, savedSiteId: Long) {
+        val savedSite = savedSiteRepo.findByIdAndUser(savedSiteId, user).orElseThrow {
+            ResponseStatusException(HttpStatus.NOT_FOUND, "즐겨찾기 목록에 없는 항목입니다.")
         }
-        val savedSite = savedSiteRepo.findByUserAndSite(user, site)
-        if (savedSite != null) {
-            savedSiteRepo.delete(savedSite)
+        savedSiteRepo.delete(savedSite)
+    }
+
+    private fun UserSavedSite.toDto(): SavedSiteResponseDto {
+        return if (this.site != null) {
+            // 공식 관측지인 경우
+            SavedSiteResponseDto(
+                savedSiteId = this.id,
+                siteId = this.site!!.id,
+                name = this.site!!.name,
+                latitude = this.site!!.latitude,
+                longitude = this.site!!.longitude,
+                isCustom = false
+            )
         } else {
-            throw ResponseStatusException(HttpStatus.NOT_FOUND, "저장되지 않은 관측지입니다.")
+            // 임의의 장소인 경우
+            SavedSiteResponseDto(
+                savedSiteId = this.id,
+                siteId = null,
+                name = this.customName ?: "이름 없음",
+                latitude = this.customLatitude ?: 0.0,
+                longitude = this.customLongitude ?: 0.0,
+                isCustom = true
+            )
         }
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -10,7 +10,7 @@ spring.datasource.username=${SPRING_DATASOURCE_USERNAME:root}
 spring.datasource.password=${SPRING_DATASOURCE_PASSWORD:root}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
-spring.jpa.hibernate.ddl-auto=update
+spring.jpa.hibernate.ddl-auto=create
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 spring.jpa.properties.hibernate.jdbc.batch_size=50


### PR DESCRIPTION
- 사용자가 임의 장소를 즐겨찾기에 추가 가능 -> 지도에서 임의 장소 클릭 후 즐겨찾기 추가
- 즐겨찾기 추가/삭제는 토글 형식(한번 입력시 추가, 재 입력시 삭제) -> 공식 장소(관측지) 및 임의 장소 토글 방식은 동일
- 즐겨찾기 목록 조회 가능
- 목록에서 상세 조회 가능 -> 관측지는 observationSiteId로 상세조회(리뷰, 좋아요, 평점, 날씨, 이름, 위경도), 임의 장소는 savedSiteId로 상세조회(이름, 위경도, 날씨)
- 즐겨찾기 목록에서도 즐겨찾기 삭제 가능