### PR TITLE
ci: PR 빌드/테스트 자동화 및 Discord 배포 알림 추가

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main, develop]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Build and Test
+        run: ./gradlew test --no-daemon
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: build/reports/tests/
+          retention-days: 7

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
                 ]
               }]
             }' \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
+            ${{ secrets.DISCORD_WEBHOOK_BACKEND_URL }}
 
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
@@ -122,7 +122,7 @@ jobs:
                 ]
               }]
             }' \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
+            ${{ secrets.DISCORD_WEBHOOK_BACKEND_URL }}
 
       - name: Notify Discord - Deploy Failure
         if: failure()
@@ -140,4 +140,4 @@ jobs:
                 ]
               }]
             }' \
-            ${{ secrets.DISCORD_WEBHOOK_URL }}
+            ${{ secrets.DISCORD_WEBHOOK_BACKEND_URL }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Notify Discord - Deploy Start
+        run: |
+          curl -s -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "🚀 별도리 서버 배포 시작",
+                "description": "새로운 버전 배포를 시작합니다.",
+                "color": 3447003,
+                "fields": [
+                  {"name": "브랜치", "value": "${{ github.ref_name }}", "inline": true},
+                  {"name": "커밋", "value": "[`'"$(echo '${{ github.sha }}' | cut -c1-7)"'`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})", "inline": true},
+                  {"name": "작업자", "value": "${{ github.actor }}", "inline": true}
+                ]
+              }]
+            }' \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+
       - name: Authenticate to GCP
         uses: google-github-actions/auth@v2
         with:
@@ -89,3 +106,38 @@ jobs:
             PUBLIC_BASE_URL=PUBLIC_BASE_URL:latest
             STORAGE_TYPE=STORAGE_TYPE:latest
             GCS_BUCKET_NAME=GCS_BUCKET_NAME:latest
+
+      - name: Notify Discord - Deploy Success
+        if: success()
+        run: |
+          curl -s -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "✅ 별도리 서버 배포 완료",
+                "description": "새로운 버전이 성공적으로 배포되었습니다.",
+                "color": 3066993,
+                "fields": [
+                  {"name": "커밋", "value": "[`'"$(echo '${{ github.sha }}' | cut -c1-7)"'`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})", "inline": true},
+                  {"name": "작업자", "value": "${{ github.actor }}", "inline": true}
+                ]
+              }]
+            }' \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}
+
+      - name: Notify Discord - Deploy Failure
+        if: failure()
+        run: |
+          curl -s -H "Content-Type: application/json" \
+            -d '{
+              "embeds": [{
+                "title": "❌ 별도리 서버 배포 실패",
+                "description": "배포 중 오류가 발생했습니다. 확인이 필요합니다.",
+                "color": 15158332,
+                "fields": [
+                  {"name": "커밋", "value": "[`'"$(echo '${{ github.sha }}' | cut -c1-7)"'`](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})", "inline": true},
+                  {"name": "작업자", "value": "${{ github.actor }}", "inline": true},
+                  {"name": "워크플로우", "value": "[${{ github.workflow }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})", "inline": false}
+                ]
+              }]
+            }' \
+            ${{ secrets.DISCORD_WEBHOOK_URL }}


### PR DESCRIPTION
## Summary

- `ci.yml` 추가 — PR 생성/업데이트 시 자동으로 빌드 + 테스트 실행
- `deploy.yml` 개선 — 배포 시작/완료/실패 시 Discord Webhook 알림

## 변경 내용

### ci.yml (신규)
- `main`, `develop` 브랜치 PR 시 트리거
- JDK 21 + Gradle 빌드 + Testcontainers 테스트 자동 실행
- 테스트 결과 아티팩트 7일 보관

### deploy.yml (수정)
- 배포 시작 시 🚀 Discord 알림 (커밋, 작업자 정보 포함)
- 배포 성공 시 ✅ Discord 알림
- 배포 실패 시 ❌ Discord 알림 (워크플로우 링크 포함)

## 사전 작업 필요
- GitHub Repository Secrets에 `DISCORD_WEBHOOK_URL` 추가 필요
  - Discord 채널 → 채널 설정 → 연동 → 웹후크 → 새 웹후크

## Test plan
- [ ] `DISCORD_WEBHOOK_URL` 시크릿 등록
- [ ] PR 생성 시 CI 워크플로우 실행 확인
- [ ] main 머지 후 Discord 채널에 알림 수신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)