### PR TITLE
feat: API 문서 자동화 (Cloudflare Pages + Stoplight Elements + oasdiff)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -172,26 +172,86 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           DISCORD_URL: ${{ secrets.DISCORD_WEBHOOK_BACKEND_URL }}
+          SHA: ${{ github.sha }}
+          ACTOR: ${{ github.actor }}
+          REPO_URL: ${{ github.server_url }}/${{ github.repository }}
         run: |
+          DOCS_URL="https://byeoldori-docs.pages.dev"
+          SHORT="${SHA:0:7}"
+
+          # 1. 이전 spec 저장 (diff 비교용)
+          curl -sf "${DOCS_URL}/openapi.json" -o openapi.old.json || echo '{"paths":{}}' > openapi.old.json
+
+          # 2. 새 spec 추출
           SERVICE_URL=$(gcloud run services describe ${{ env.SERVICE_NAME }} \
             --region=${{ env.REGION }} --format='value(status.url)')
-
           curl -s "${SERVICE_URL}/v3/api-docs" -o docs/openapi.json
           echo "OpenAPI spec 추출 완료"
 
+          # 3. oasdiff 설치 및 changelog 생성
+          curl -fsSL https://github.com/oasdiff/oasdiff/releases/latest/download/oasdiff_Linux_amd64.tar.gz \
+            | tar xz oasdiff
+          chmod +x oasdiff
+
+          DIFF_SUMMARY=$(python3 << 'PYEOF'
+          import subprocess, json, sys
+
+          result = subprocess.run(
+            ['./oasdiff', 'changelog', 'openapi.old.json', 'docs/openapi.json', '-f', 'json'],
+            capture_output=True, text=True
+          )
+
+          try:
+            changes = json.loads(result.stdout) if result.stdout.strip() else []
+          except:
+            changes = []
+
+          added   = [c for c in changes if 'endpoint-added' in c.get('id','')]
+          removed = [c for c in changes if 'endpoint-removed' in c.get('id','')]
+          breaking = [c for c in changes if c.get('level', 0) >= 2]
+          modified = [c for c in changes if c not in added and c not in removed and c not in breaking]
+
+          lines = []
+          if added:
+            lines.append(f"🟢 추가된 엔드포인트 ({len(added)})")
+            for c in added[:5]:
+              lines.append(f"  {c.get('text','').strip()}")
+          if removed:
+            lines.append(f"🔴 삭제된 엔드포인트 ({len(removed)})")
+            for c in removed[:5]:
+              lines.append(f"  {c.get('text','').strip()}")
+          if breaking:
+            lines.append(f"⚠️ Breaking Changes ({len(breaking)})")
+            for c in breaking[:3]:
+              lines.append(f"  {c.get('text','').strip()}")
+          if modified and not added and not removed and not breaking:
+            lines.append(f"🔵 변경된 항목 ({len(modified)})")
+            for c in modified[:5]:
+              lines.append(f"  {c.get('text','').strip()}")
+          if not lines:
+            lines.append("변경된 API 없음 (내부 로직/스키마만 업데이트)")
+
+          print('\n'.join(lines))
+          PYEOF
+          )
+
+          # 4. Cloudflare Pages 배포
           npm install -g wrangler --silent
           wrangler pages deploy docs/ \
             --project-name=byeoldori-docs \
             --commit-dirty=true
 
-          DOCS_URL="https://byeoldori-docs.pages.dev"
+          # 5. Discord 알림 (diff 포함)
+          DIFF_JSON=$(echo "$DIFF_SUMMARY" | python3 -c "import json,sys; print(json.dumps(sys.stdin.read()))")
           curl -s -H "Content-Type: application/json" \
             -d "{
               \"embeds\": [{
                 \"title\": \"📄 API 문서 업데이트\",
-                \"description\": \"새로운 버전의 API 문서가 배포되었습니다.\",
                 \"color\": 5793266,
                 \"fields\": [
+                  {\"name\": \"변경사항\", \"value\": \"\`\`\`${DIFF_SUMMARY}\`\`\`\", \"inline\": false},
+                  {\"name\": \"커밋\", \"value\": \"[\`${SHORT}\`](${REPO_URL}/commit/${SHA})\", \"inline\": true},
+                  {\"name\": \"작업자\", \"value\": \"${ACTOR}\", \"inline\": true},
                   {\"name\": \"문서\", \"value\": \"[열기](${DOCS_URL})\", \"inline\": true}
                 ]
               }]

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,19 +2,110 @@
 <html lang="ko">
 <head>
   <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-  <title>별도리 API 문서</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>별도리 API Docs</title>
   <script src="https://unpkg.com/@stoplight/elements/web-components.min.js"></script>
   <link rel="stylesheet" href="https://unpkg.com/@stoplight/elements/styles.min.css">
   <style>
-    html, body { height: 100%; margin: 0; }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Noto Sans KR', sans-serif;
+    }
+
+    .header {
+      background: linear-gradient(135deg, #0b0f1e 0%, #111827 100%);
+      border-bottom: 1px solid #1e2d4a;
+      padding: 0 24px;
+      height: 52px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      flex-shrink: 0;
+      z-index: 100;
+    }
+
+    .header-logo { font-size: 20px; }
+
+    .header-title {
+      font-size: 15px;
+      font-weight: 700;
+      color: #e2e8f0;
+      letter-spacing: -0.2px;
+    }
+
+    .header-badge {
+      background: #1e3a5f;
+      color: #60a5fa;
+      font-size: 10px;
+      font-weight: 600;
+      padding: 2px 8px;
+      border-radius: 10px;
+      letter-spacing: 0.4px;
+      text-transform: uppercase;
+    }
+
+    .header-sep {
+      width: 1px;
+      height: 18px;
+      background: #1e2d4a;
+      margin: 0 4px;
+    }
+
+    .header-env {
+      font-size: 11px;
+      color: #34d399;
+      font-weight: 500;
+      display: flex;
+      align-items: center;
+      gap: 5px;
+    }
+
+    .header-env::before {
+      content: '';
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: #34d399;
+      display: inline-block;
+      box-shadow: 0 0 6px #34d399;
+    }
+
+    .header-right {
+      margin-left: auto;
+      font-size: 11px;
+      color: #475569;
+    }
+
+    .docs-wrap {
+      flex: 1;
+      overflow: hidden;
+      display: flex;
+    }
+
+    elements-api {
+      flex: 1;
+    }
   </style>
 </head>
 <body>
-  <elements-api
-    apiDescriptionUrl="./openapi.json"
-    router="hash"
-    layout="sidebar"
-  />
+  <header class="header">
+    <span class="header-logo">⭐</span>
+    <span class="header-title">별도리 API</span>
+    <span class="header-badge">v1.0</span>
+    <div class="header-sep"></div>
+    <span class="header-env">Production</span>
+    <span class="header-right">Byeoldori Backend · Internal Docs</span>
+  </header>
+  <div class="docs-wrap">
+    <elements-api
+      apiDescriptionUrl="./openapi.json"
+      router="hash"
+      layout="sidebar"
+    />
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- `docs/index.html` — 별도리 브랜딩 헤더 + 다크 네이비 테마 API 문서 페이지
- `deploy.yml` — 배포 완료 후 OpenAPI spec 자동 추출 → Cloudflare Pages 배포 + Discord 변경사항 알림

## 동작 흐름

```
main 머지 → 서버 배포 → 헬스체크 통과
    ↓
기존 spec 저장 (byeoldori-docs.pages.dev/openapi.json)
새 spec 추출 (Cloud Run /v3/api-docs)
    ↓
oasdiff로 추가/삭제/변경 엔드포인트 분석
    ↓
Cloudflare Pages 자동 배포
    ↓
Discord에 변경사항 포함한 📄 알림
```

## Discord 알림 예시

```
📄 API 문서 업데이트
변경사항
🟢 추가된 엔드포인트 (1)
  endpoint added POST /notifications/fcm-token
🔵 변경된 항목 (1)
  request parameter added 'region' in GET /weather/ForecastData

커밋 `abc1234` | 작업자 Seobeomsu | 문서 열기
```

## 결과물

- **문서 URL**: https://byeoldori-docs.pages.dev
- **기능**: 사이드바 탐색 + JWT 입력 후 직접 테스트
- **업데이트**: main 배포 성공 시 자동

## 사전 조건 (완료)

- [x] Cloudflare Pages 프로젝트 `byeoldori-docs` 생성
- [x] GitHub Secrets `CLOUDFLARE_API_TOKEN` 등록
- [x] GitHub Secrets `CLOUDFLARE_ACCOUNT_ID` 등록

🤖 Generated with [Claude Code](https://claude.com/claude-code)