### PR TITLE
fix: YAML 파싱 오류 수정 - OpenAPI diff 스크립트 분리

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -188,51 +188,8 @@ jobs:
           curl -s "${SERVICE_URL}/v3/api-docs" -o docs/openapi.json
           echo "OpenAPI spec 추출 완료"
 
-          # 3. Python으로 OpenAPI diff 분석
-          python3 -c "
-import json
-
-def load(path):
-    try:
-        with open(path) as f:
-            return json.load(f)
-    except:
-        return {'paths': {}}
-
-old = load('openapi.old.json')
-new = load('docs/openapi.json')
-
-old_endpoints = set()
-new_endpoints = set()
-
-for path, methods in old.get('paths', {}).items():
-    for method in methods:
-        if method in ('get','post','put','patch','delete'):
-            old_endpoints.add(f'{method.upper()} {path}')
-
-for path, methods in new.get('paths', {}).items():
-    for method in methods:
-        if method in ('get','post','put','patch','delete'):
-            new_endpoints.add(f'{method.upper()} {path}')
-
-added   = sorted(new_endpoints - old_endpoints)
-removed = sorted(old_endpoints - new_endpoints)
-
-lines = []
-if added:
-    lines.append(f'🟢 추가된 엔드포인트 ({len(added)})')
-    for e in added[:5]:
-        lines.append(f'  {e}')
-if removed:
-    lines.append(f'🔴 삭제된 엔드포인트 ({len(removed)})')
-    for e in removed[:5]:
-        lines.append(f'  {e}')
-if not lines:
-    lines.append('변경된 API 없음 (내부 로직/스키마만 업데이트)')
-
-print('\n'.join(lines))
-" > /tmp/diff_output.txt
-          DIFF_SUMMARY=$(cat /tmp/diff_output.txt)
+          # 3. OpenAPI diff 분석
+          DIFF_SUMMARY=$(python3 scripts/diff_openapi.py openapi.old.json docs/openapi.json)
 
           # 4. Cloudflare Pages 배포
           npm install -g wrangler --silent

--- a/scripts/diff_openapi.py
+++ b/scripts/diff_openapi.py
@@ -1,0 +1,37 @@
+import json
+import sys
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return {'paths': {}}
+
+def endpoints(spec):
+    result = set()
+    for path, methods in spec.get('paths', {}).items():
+        for method in methods:
+            if method in ('get', 'post', 'put', 'patch', 'delete'):
+                result.add(f'{method.upper()} {path}')
+    return result
+
+old = load(sys.argv[1])
+new = load(sys.argv[2])
+
+added   = sorted(endpoints(new) - endpoints(old))
+removed = sorted(endpoints(old) - endpoints(new))
+
+lines = []
+if added:
+    lines.append(f'🟢 추가된 엔드포인트 ({len(added)})')
+    for e in added[:5]:
+        lines.append(f'  {e}')
+if removed:
+    lines.append(f'🔴 삭제된 엔드포인트 ({len(removed)})')
+    for e in removed[:5]:
+        lines.append(f'  {e}')
+if not lines:
+    lines.append('변경된 API 없음 (내부 로직/스키마만 업데이트)')
+
+print('\n'.join(lines))


### PR DESCRIPTION
## 원인

`deploy.yml`의 `run: |` 블록 안에 `python3 -c "..."` 인라인 코드가 있었는데, Python 코드 줄들이 들여쓰기 0에서 시작해서 YAML 파서가 블록 스칼라가 끝난 것으로 잘못 인식 → workflow file issue 오류 발생

## 수정

- `scripts/diff_openapi.py` 파일로 분리
- deploy.yml에서 `python3 scripts/diff_openapi.py openapi.old.json docs/openapi.json` 한 줄 호출로 대체

🤖 Generated with [Claude Code](https://claude.com/claude-code)