### PR TITLE
feat: API 문서 Fumadocs + Cloudflare Pages 공식 Action 연동

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      deployments: write
 
     steps:
       - uses: actions/checkout@v4
@@ -199,13 +200,7 @@ jobs:
           npm run build
           cd ..
 
-          # 5. Cloudflare Pages 배포
-          npm install -g wrangler --silent
-          wrangler pages deploy docs-site/out \
-            --project-name=byeoldori-docs \
-            --commit-dirty=true
-
-          # 6. Discord 알림
+          # 5. Discord 알림 (Cloudflare 배포 전)
           curl -s -H "Content-Type: application/json" \
             -d "{
               \"embeds\": [{
@@ -220,6 +215,16 @@ jobs:
               }]
             }" \
             "$DISCORD_URL"
+
+      - name: Deploy docs to Cloudflare Pages
+        if: success()
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: byeoldori-docs
+          directory: docs-site/out
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Notify Discord - Deploy Success
         if: success()


### PR DESCRIPTION
## Summary

- API 문서 사이트를 **Fumadocs + Next.js** 기반으로 구축
- **Cloudflare Pages 공식 Action** (`cloudflare/pages-action@v1`) 적용
- GitHub Actions UI에서 배포 상태 및 URL 직접 확인 가능

## 스택

| | 이전 | 이후 |
|--|--|--|
| 프레임워크 | Stoplight Elements (정적 HTML) | **Fumadocs + Next.js 16** |
| OpenAPI | - | **fumadocs-openapi + Scalar** |
| CF 배포 | wrangler CLI 수동 | **cloudflare/pages-action@v1** |

## 배포 흐름

```
서버 배포 + 헬스체크 통과
    ↓
Cloud Run에서 openapi.json 추출
    ↓
npm run generate (openapi.json → MDX)
npm run build (Next.js → out/)
    ↓
cloudflare/pages-action → byeoldori-docs.pages.dev
    ↓
Discord 알림
```

## GitHub Actions에서 보이는 것

```
✅ Deploy docs to Cloudflare Pages
   🌍 https://byeoldori-docs.pages.dev
   📋 Deployment ID: ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)