### PR TITLE
fix: docs.yml npm 캐시 오류 수정 및 워크플로우 분리

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,8 +38,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
-          cache-dependency-path: docs-site/package-lock.json
 
       - name: Fetch openapi.json from server
         run: |
@@ -59,7 +57,7 @@ jobs:
           echo "DIFF_SUMMARY=${DIFF}" >> $GITHUB_ENV
 
       - name: Install dependencies
-        run: npm ci --prefix docs-site
+        run: npm install --prefix docs-site
 
       - name: Generate API docs from openapi.json
         run: npm run generate --prefix docs-site


### PR DESCRIPTION
## Summary

- `package-lock.json` 없어서 npm 캐시 설정 실패 → 캐시 제거
- `npm ci` → `npm install` 변경
- 서버 배포(`deploy.yml`) / 문서 배포(`docs.yml`) 완전 분리 유지

## 워크플로우 구조

```
deploy.yml  → Cloud Run 서버 배포만 담당
                    ↓ 성공 시 자동 트리거
docs.yml    → openapi.json 추출 → Fumadocs 빌드 → Cloudflare Pages
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)