### PR TITLE
docs: 백엔드 연동 가이드 + 구현 상세 MDX 추가

### DIFF
--- a/docs-site/content/docs/guide/authentication.mdx
+++ b/docs-site/content/docs/guide/authentication.mdx
@@ -1,0 +1,95 @@
+---
+title: 인증 플로우
+description: 회원가입부터 토큰 관리까지 전체 인증 흐름
+---
+
+## 엔드포인트 요약
+
+| 메서드 | 경로 | 설명 | 인증 필요 |
+|--------|------|------|----------|
+| POST | `/auth/signup` | 회원가입 | ❌ |
+| GET | `/auth/verify-email?token=` | 이메일 인증 | ❌ |
+| POST | `/auth/login` | 로그인 | ❌ |
+| POST | `/auth/token` | 액세스 토큰 재발급 | ❌ |
+| POST | `/users/logout` | 로그아웃 (서버 리프레시 삭제) | ✅ |
+| GET | `/users/me` | 내 정보 조회 | ✅ |
+| POST | `/auth/google` | Google ID Token 로그인 | ❌ |
+
+---
+
+## 회원가입 → 로그인 플로우
+
+```
+1. POST /auth/signup
+2. 이메일 수신 → GET /auth/verify-email?token=...
+3. POST /auth/login → accessToken, refreshToken 저장
+4. GET /users/me → 내 정보 확인
+```
+
+### 회원가입 요청
+
+```json
+POST /auth/signup
+{
+  "email": "user@example.com",
+  "password": "Abcd1234!",
+  "passwordConfirm": "Abcd1234!",
+  "name": "홍길동",
+  "phone": "01012345678"
+}
+```
+
+### 로그인 응답
+
+```json
+{
+  "data": {
+    "accessToken": "eyJ...",
+    "refreshToken": "eyJ...",
+    "accessTokenExpiresAt": "2024-01-01T01:00:00Z",
+    "refreshTokenExpiresAt": "2024-01-15T00:00:00Z"
+  }
+}
+```
+
+> ⚠️ `/auth/verify-email` 응답은 JSON이 아닌 HTML 문자열 `"verification-success"` 반환합니다.
+
+---
+
+## 토큰 재발급
+
+액세스 토큰 만료(401) 시 리프레시 토큰으로 재발급합니다.
+
+```json
+POST /auth/token
+{
+  "refreshToken": "eyJ..."
+}
+```
+
+재발급도 실패하면(401) → 로그아웃 처리 후 `/login` 이동.
+
+---
+
+## Google OAuth
+
+현재 서버는 앱에서 받은 Google ID Token 검증 방식으로 구현되어 있습니다.
+
+```json
+POST /auth/google
+{
+  "idToken": "구글에서 받은 ID Token"
+}
+```
+
+> ⚠️ 웹용 Google OAuth는 **웹용 Client ID 별도 발급** 및 **콜백 URL 등록**이 필요합니다.
+> 현재 미구현 상태입니다.
+
+---
+
+## 릴리스 전 복구 항목
+
+| 항목 | 현재 상태 | 복구 내용 |
+|------|----------|----------|
+| AuthGuard 리다이렉트 | 제거됨 | 미로그인 시 `/login`으로 이동 복구 |
+| 세션 만료 UX | 하드 네비게이션 | `router.push('/login')`으로 교체 |

--- a/docs-site/content/docs/guide/authentication.mdx
+++ b/docs-site/content/docs/guide/authentication.mdx
@@ -11,7 +11,7 @@ description: 회원가입부터 토큰 관리까지 전체 인증 흐름
 | GET | `/auth/verify-email?token=` | 이메일 인증 | ❌ |
 | POST | `/auth/login` | 로그인 | ❌ |
 | POST | `/auth/token` | 액세스 토큰 재발급 | ❌ |
-| POST | `/users/logout` | 로그아웃 (서버 리프레시 삭제) | ✅ |
+| POST | `/users/logout` | 로그아웃 | ✅ |
 | GET | `/users/me` | 내 정보 조회 | ✅ |
 | POST | `/auth/google` | Google ID Token 로그인 | ❌ |
 
@@ -39,6 +39,9 @@ POST /auth/signup
 }
 ```
 
+> ⚠️ **이메일 인증 필수** — 인증 전 로그인 시도하면 `403 Forbidden` 반환합니다.
+> `/auth/verify-email` 응답은 JSON이 아닌 HTML 문자열 `"verification-success"`를 반환합니다.
+
 ### 로그인 응답
 
 ```json
@@ -46,44 +49,101 @@ POST /auth/signup
   "data": {
     "accessToken": "eyJ...",
     "refreshToken": "eyJ...",
-    "accessTokenExpiresAt": "2024-01-01T01:00:00Z",
-    "refreshTokenExpiresAt": "2024-01-15T00:00:00Z"
+    "accessTokenExpiresAt": "2024-01-01T01:00:00",
+    "refreshTokenExpiresAt": "2024-01-15T00:00:00"
   }
 }
 ```
 
-> ⚠️ `/auth/verify-email` 응답은 JSON이 아닌 HTML 문자열 `"verification-success"` 반환합니다.
+---
+
+## JWT 구현 상세
+
+서버는 **HMAC-SHA256** 서명 방식으로 JWT를 발급합니다.
+
+```
+accessToken  만료: 1시간 (3,600,000ms)
+refreshToken 만료: 14일 (1,209,600,000ms)
+```
+
+토큰 페이로드:
+- `sub` — 사용자 이메일
+- `typ` — `"access"` 또는 `"refresh"` (타입 구분용 커스텀 클레임)
+- `iat` / `exp` — 발급/만료 시각
+
+> **클라이언트 구현 포인트:** `typ` 클레임으로 액세스/리프레시 구분이 가능하지만, 일반적으로 localStorage 키로 구분하면 충분합니다.
 
 ---
 
-## 토큰 재발급
+## 리프레시 토큰 보안
 
-액세스 토큰 만료(401) 시 리프레시 토큰으로 재발급합니다.
+서버는 리프레시 토큰 자체를 DB에 저장하지 않고 **SHA-256 해시만 저장**합니다.
+
+```
+DB: refresh_tokens 테이블
+- user_id (unique) — 사용자당 토큰 1개만 유지
+- token_hash — SHA-256(refreshToken) 저장
+- expires_at
+- revoked_at / rotated_at
+```
+
+재발급 시 동작:
+1. 클라이언트가 보낸 `refreshToken`을 SHA-256 해싱
+2. DB의 `tokenHash`와 비교 — 불일치 시 `401`
+3. 만료/폐기 여부 확인
+4. 새 accessToken + refreshToken 발급, DB 해시 업데이트 (토큰 로테이션)
 
 ```json
 POST /auth/token
-{
-  "refreshToken": "eyJ..."
-}
+{ "refreshToken": "eyJ..." }
 ```
 
-재발급도 실패하면(401) → 로그아웃 처리 후 `/login` 이동.
+재발급 실패(401) 시 → 로그아웃 처리 후 `/login` 이동.
 
 ---
 
-## Google OAuth
+## Rate Limiting
 
-현재 서버는 앱에서 받은 Google ID Token 검증 방식으로 구현되어 있습니다.
+Redis 기반 IP별 요청 제한이 적용되어 있습니다.
+
+| 경로 | 제한 | 시간 |
+|------|------|------|
+| `/auth/login` | 10회 | 1분 |
+| `/auth/signup` | 5회 | 1분 |
+| `/auth/password/reset-request` | 3회 | 1시간 |
+| `/auth/google` | 10회 | 1분 |
+
+초과 시 `429 Too Many Requests` 반환.
+
+---
+
+## Google OAuth 구현 상세
+
+서버는 **Google ID Token 검증 방식**으로 구현되어 있습니다. (앱 → 구글 → ID Token → 서버 검증)
 
 ```json
 POST /auth/google
-{
-  "idToken": "구글에서 받은 ID Token"
-}
+{ "idToken": "구글에서 발급받은 ID Token" }
 ```
 
+서버 동작:
+1. Google API로 ID Token 검증
+2. 기존 계정 있으면 로그인, 없으면 자동 회원가입
+3. Google 계정은 `provider: "google"`, `providerId: sub` 저장
+4. 일반 계정으로 로그인 시도하면 → `"google 계정입니다. google으로 로그인해주세요."` 에러
+
 > ⚠️ 웹용 Google OAuth는 **웹용 Client ID 별도 발급** 및 **콜백 URL 등록**이 필요합니다.
-> 현재 미구현 상태입니다.
+
+---
+
+## 로그아웃
+
+```
+POST /users/logout   (Authorization 헤더 필요)
+```
+
+서버에서 DB의 `refresh_tokens` 레코드를 삭제합니다.
+클라이언트에서는 `localStorage`의 토큰도 함께 제거해야 합니다.
 
 ---
 
@@ -92,4 +152,4 @@ POST /auth/google
 | 항목 | 현재 상태 | 복구 내용 |
 |------|----------|----------|
 | AuthGuard 리다이렉트 | 제거됨 | 미로그인 시 `/login`으로 이동 복구 |
-| 세션 만료 UX | 하드 네비게이션 | `router.push('/login')`으로 교체 |
+| 세션 만료 UX | `window.location.href='/login'` | `router.push('/login')`으로 교체 |

--- a/docs-site/content/docs/guide/calendar.mdx
+++ b/docs-site/content/docs/guide/calendar.mdx
@@ -1,6 +1,6 @@
 ---
-title: 관측 일정
-description: 캘린더 이벤트 CRUD
+title: 관측 일정 (캘린더)
+description: 관측 이벤트 CRUD 및 구현 상세
 ---
 
 ## 엔드포인트
@@ -14,12 +14,81 @@ description: 캘린더 이벤트 CRUD
 | PATCH | `/calendar/events/{id}` | 수정 |
 | DELETE | `/calendar/events/{id}` | 삭제 |
 | POST | `/calendar/events/{id}/complete` | 완료 처리 |
-| GET | `/calendar/events/count` | 총 관측 횟수 |
+| GET | `/calendar/events/count` | 총 완료 관측 횟수 |
 
-## 일정 상태
+---
 
-| 상태 | 설명 |
-|------|------|
+## 일정 상태 (status)
+
+| 값 | 설명 |
+|----|------|
 | `PLANNED` | 예정 |
-| `COMPLETED` | 완료 |
+| `COMPLETED` | 완료 (관측 기록) |
 | `CANCELED` | 취소 |
+
+> `COMPLETED` 상태로 직접 생성하면 `endAt`이 자동으로 `startAt`으로 설정됩니다.
+
+---
+
+## 이벤트 생성
+
+```json
+POST /calendar/events
+{
+  "title": "M42 오리온 성운 관측",
+  "startAt": "2024-01-15T20:00",
+  "endAt": "2024-01-15T23:00",
+  "status": "PLANNED",
+  "observationSiteId": 1,
+  "lat": 37.5,
+  "lon": 127.0,
+  "placeName": "자택 옥상",
+  "memo": "망원경 80mm 사용 예정",
+  "targets": ["M42", "M45"],
+  "imageUrls": ["https://..."]
+}
+```
+
+- `observationSiteId`가 있으면 해당 관측지의 위경도/이름으로 자동 채움
+- `targets` — 관측 대상 천체 목록 (star 모듈과 연동)
+- 이미지는 이벤트당 최대 **10장**
+
+---
+
+## 완료 처리
+
+```json
+POST /calendar/events/{id}/complete
+{
+  "observedAt": "2024-01-15T23:30"  // 생략 시 endAt 또는 startAt 사용
+}
+```
+
+---
+
+## 월별 요약
+
+```
+GET /calendar/events/month?year=2024&month=1
+```
+
+응답: 날짜별 `planned` / `completed` / `canceled` 건수
+
+```json
+{
+  "data": [
+    { "date": "2024-01-15", "planned": 1, "completed": 0, "canceled": 0 },
+    { "date": "2024-01-20", "planned": 0, "completed": 1, "canceled": 0 }
+  ]
+}
+```
+
+> 캘린더 UI에서 날짜 뱃지를 표시할 때 이 API를 사용합니다.
+
+---
+
+## 구현 상세
+
+- 날짜/시간은 **초/나노초를 0으로 정규화**해서 저장합니다. (`2024-01-15T20:00:00`)
+- `startAt`이 `endAt`보다 늦으면 `400 Bad Request`
+- 이벤트 삭제 시 첨부 이미지도 스토리지에서 삭제됩니다 (트랜잭션 커밋 후)

--- a/docs-site/content/docs/guide/calendar.mdx
+++ b/docs-site/content/docs/guide/calendar.mdx
@@ -1,0 +1,25 @@
+---
+title: 관측 일정
+description: 캘린더 이벤트 CRUD
+---
+
+## 엔드포인트
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| POST | `/calendar/events` | 일정 생성 |
+| GET | `/calendar/events/date?date=YYYY-MM-DD` | 날짜별 조회 |
+| GET | `/calendar/events/month?year=YYYY&month=M` | 월별 요약 |
+| GET | `/calendar/events/{id}` | 단건 조회 |
+| PATCH | `/calendar/events/{id}` | 수정 |
+| DELETE | `/calendar/events/{id}` | 삭제 |
+| POST | `/calendar/events/{id}/complete` | 완료 처리 |
+| GET | `/calendar/events/count` | 총 관측 횟수 |
+
+## 일정 상태
+
+| 상태 | 설명 |
+|------|------|
+| `PLANNED` | 예정 |
+| `COMPLETED` | 완료 |
+| `CANCELED` | 취소 |

--- a/docs-site/content/docs/guide/community.mdx
+++ b/docs-site/content/docs/guide/community.mdx
@@ -1,39 +1,83 @@
 ---
 title: 커뮤니티 API
-description: 게시글, 댓글, 좋아요 CRUD
+description: 게시글, 댓글, 좋아요 CRUD 및 구현 상세
 ---
 
 ## 게시글 타입
 
-`type` 파라미터는 `FREE` / `REVIEW` / `EDUCATION` 중 하나입니다.
+`type` 파라미터: `FREE` / `REVIEW` / `EDUCATION`
 
-## 게시글
+## 게시글 엔드포인트
 
 | 메서드 | 경로 | 설명 |
 |--------|------|------|
 | POST | `/community/{type}/posts` | 작성 |
 | GET | `/community/{type}/posts` | 목록 조회 |
-| GET | `/community/posts/{id}` | 상세 조회 |
+| GET | `/community/posts/{id}` | 상세 조회 (조회수 +1) |
 | PATCH | `/community/posts/{id}` | 수정 |
 | DELETE | `/community/posts/{id}` | 삭제 |
+| POST | `/community/posts/{id}/likes/toggle` | 좋아요 토글 |
 
 ### 목록 조회 파라미터
 
 | 파라미터 | 기본값 | 설명 |
 |---------|--------|------|
-| `page` | `0` | 페이지 번호 |
+| `page` | `0` | 페이지 번호 (0부터 시작) |
 | `size` | `20` | 페이지 크기 |
 | `sortBy` | `LATEST` | `LATEST` / `VIEWS` / `LIKES` |
 | `keyword` | - | 검색어 |
 | `searchBy` | `TITLE` | `TITLE` / `CONTENT` / `NICKNAME` |
 
+> **검색 구현:** `TITLE`, `CONTENT`는 MySQL FULLTEXT 인덱스 기반 자연어 검색입니다. `NICKNAME`은 LIKE 검색입니다.
+
 ### 홈 화면 API
 
 ```
-GET /community/home/reviews       — 최신 관측 후기
-GET /community/home/educations    — 신규 교육 콘텐츠
-GET /community/home/free-posts    — 인기 자유게시글
+GET /community/home/reviews       — 최신 관측 후기 (최대 20개)
+GET /community/home/educations    — 신규 교육 콘텐츠 (최대 20개)
+GET /community/home/free-posts    — 인기 자유게시글, 조회수 기준 (최대 20개)
 ```
+
+---
+
+## 게시글 타입별 추가 필드
+
+### REVIEW (관측 후기)
+
+```json
+{
+  "title": "...",
+  "content": "...",
+  "review": {
+    "location": "강원도 인제",
+    "observationSiteId": 1,
+    "equipment": "망원경 80mm",
+    "observationDate": "2024-01-01",
+    "score": 5,
+    "targets": ["M42", "M45"]
+  },
+  "imageUrls": ["https://..."]
+}
+```
+
+### EDUCATION (교육 콘텐츠)
+
+```json
+{
+  "title": "...",
+  "content": "...",
+  "education": {
+    "difficulty": "BEGINNER",
+    "tags": "천문,별자리",
+    "status": "PUBLISHED",
+    "contentUrl": "https://.../content.json",
+    "targets": ["오리온자리"]
+  }
+}
+```
+
+> `contentUrl`은 `/files/json`으로 업로드한 JSON 파일 URL입니다.
+> 서버에서 `PUBLIC_BASE_URL`로 시작하는 URL만 허용합니다.
 
 ---
 
@@ -42,9 +86,10 @@ GET /community/home/free-posts    — 인기 자유게시글
 | 메서드 | 경로 | 설명 |
 |--------|------|------|
 | POST | `/community/posts/{id}/comments` | 작성 |
-| GET | `/community/posts/{id}/comments` | 목록 (`?page=1&size=15`) |
+| GET | `/community/posts/{id}/comments?page=1&size=15` | 목록 |
 | PATCH | `/community/posts/{id}/comments/{cid}` | 수정 |
 | DELETE | `/community/posts/{id}/comments/{cid}` | 삭제 |
+| POST | `/community/posts/{id}/comments/{cid}/likes-toggle` | 댓글 좋아요 |
 
 대댓글은 `parentId` 필드를 포함합니다.
 
@@ -56,9 +101,11 @@ POST /community/posts/{id}/comments
 }
 ```
 
+> **댓글 수** — 댓글 작성/삭제 시 서버가 `community_posts.comment_count`를 자동 갱신합니다. 별도 카운트 조회 API 없이 게시글 상세의 `commentCount` 필드를 사용하세요.
+
 ---
 
-## 좋아요 토글
+## 좋아요 구현 상세
 
 ```
 POST /community/posts/{id}/likes/toggle          — 게시글 좋아요
@@ -75,21 +122,24 @@ POST /community/posts/{id}/comments/{cid}/likes-toggle  — 댓글 좋아요
 }
 ```
 
+서버 구현: 좋아요 토글 시 `like_count`를 직접 UPDATE합니다. 낙관적 락을 사용하지 않으므로 동시 요청 시 count가 틀릴 수 있지만, 소규모 서비스에서는 허용 가능한 수준입니다.
+
 ---
 
-## 교육 콘텐츠 평가
+## 이미지 첨부 플로우
 
-```json
-POST /community/posts/{id}/evaluations
-{
-  "score": 5,          // 1~5
-  "pros": "좋았던 점",
-  "cons": "개선할 점"
-}
+```
+1. POST /files/image → url 반환
+2. 게시글 작성 시 imageUrls 배열에 포함
+3. 게시글 수정 시 imageUrls로 최종 목록 전달 (없는 URL은 삭제)
 ```
 
+> **게시글 삭제 시** 서버가 트랜잭션 커밋 후 스토리지에서 이미지 파일도 삭제합니다.
+
 ---
 
-## 미구현 항목
+## ⚠️ 미구현 항목
 
-> ❌ **내가 쓴 글/댓글/좋아요 목록** — 서버에 해당 엔드포인트 없음. 구현 전 서버 작업 필요.
+- **내가 쓴 글 목록** — 서버 엔드포인트 없음, 구현 전 서버 작업 필요
+- **내가 좋아요한 글 목록** — 서버 엔드포인트 없음
+- **교육 콘텐츠 평가 조회** — 작성은 가능하나 내 평가 조회 API 없음

--- a/docs-site/content/docs/guide/community.mdx
+++ b/docs-site/content/docs/guide/community.mdx
@@ -1,0 +1,95 @@
+---
+title: 커뮤니티 API
+description: 게시글, 댓글, 좋아요 CRUD
+---
+
+## 게시글 타입
+
+`type` 파라미터는 `FREE` / `REVIEW` / `EDUCATION` 중 하나입니다.
+
+## 게시글
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| POST | `/community/{type}/posts` | 작성 |
+| GET | `/community/{type}/posts` | 목록 조회 |
+| GET | `/community/posts/{id}` | 상세 조회 |
+| PATCH | `/community/posts/{id}` | 수정 |
+| DELETE | `/community/posts/{id}` | 삭제 |
+
+### 목록 조회 파라미터
+
+| 파라미터 | 기본값 | 설명 |
+|---------|--------|------|
+| `page` | `0` | 페이지 번호 |
+| `size` | `20` | 페이지 크기 |
+| `sortBy` | `LATEST` | `LATEST` / `VIEWS` / `LIKES` |
+| `keyword` | - | 검색어 |
+| `searchBy` | `TITLE` | `TITLE` / `CONTENT` / `NICKNAME` |
+
+### 홈 화면 API
+
+```
+GET /community/home/reviews       — 최신 관측 후기
+GET /community/home/educations    — 신규 교육 콘텐츠
+GET /community/home/free-posts    — 인기 자유게시글
+```
+
+---
+
+## 댓글
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| POST | `/community/posts/{id}/comments` | 작성 |
+| GET | `/community/posts/{id}/comments` | 목록 (`?page=1&size=15`) |
+| PATCH | `/community/posts/{id}/comments/{cid}` | 수정 |
+| DELETE | `/community/posts/{id}/comments/{cid}` | 삭제 |
+
+대댓글은 `parentId` 필드를 포함합니다.
+
+```json
+POST /community/posts/{id}/comments
+{
+  "content": "댓글 내용",
+  "parentId": 123  // 대댓글인 경우만
+}
+```
+
+---
+
+## 좋아요 토글
+
+```
+POST /community/posts/{id}/likes/toggle          — 게시글 좋아요
+POST /community/posts/{id}/comments/{cid}/likes-toggle  — 댓글 좋아요
+```
+
+응답:
+```json
+{
+  "data": {
+    "liked": true,
+    "likeCount": 5
+  }
+}
+```
+
+---
+
+## 교육 콘텐츠 평가
+
+```json
+POST /community/posts/{id}/evaluations
+{
+  "score": 5,          // 1~5
+  "pros": "좋았던 점",
+  "cons": "개선할 점"
+}
+```
+
+---
+
+## 미구현 항목
+
+> ❌ **내가 쓴 글/댓글/좋아요 목록** — 서버에 해당 엔드포인트 없음. 구현 전 서버 작업 필요.

--- a/docs-site/content/docs/guide/file-upload.mdx
+++ b/docs-site/content/docs/guide/file-upload.mdx
@@ -1,30 +1,24 @@
 ---
 title: 파일 업로드
-description: 이미지 및 JSON 파일 업로드 제한사항
+description: 이미지 및 JSON 파일 업로드 — 구현 상세와 제한사항
 ---
 
 ## 엔드포인트
 
-| 메서드 | 경로 | 설명 |
-|--------|------|------|
-| POST | `/files/image` | 이미지 업로드 |
-| POST | `/files/json` | 교육 콘텐츠 JSON 업로드 |
-| POST | `/users/me/profile-image` | 프로필 이미지 업로드 |
+| 메서드 | 경로 | key 이름 | 설명 |
+|--------|------|---------|------|
+| POST | `/files/image` | `file` | 게시글/캘린더 이미지 |
+| POST | `/files/json` | `file` | 교육 콘텐츠 JSON |
+| POST | `/users/me/profile-image` | `image` | 프로필 이미지 |
 
-모두 `multipart/form-data` 형식입니다.
-
-```
-/files/image         → form-data key: "file"
-/files/json          → form-data key: "file"
-/users/me/profile-image → form-data key: "image"
-```
+모두 `Content-Type: multipart/form-data`
 
 ## 응답
 
 ```json
 {
   "data": {
-    "url": "https://...",
+    "url": "https://storage.googleapis.com/...",
     "filename": "image.jpg",
     "size": 204800,
     "contentType": "image/jpeg"
@@ -32,13 +26,55 @@ description: 이미지 및 JSON 파일 업로드 제한사항
 }
 ```
 
-## ⚠️ Vercel 프록시 제한
+반환된 `url`을 게시글 생성 요청의 `imageUrls` 필드에 담아 사용합니다.
 
-Vercel Route Handler 프록시를 통해 업로드하면 **4.5MB** 제한이 있습니다.
+---
 
-| 파일 크기 | 방법 |
-|----------|------|
-| 4.5MB 이하 | Vercel 프록시 통해 정상 업로드 |
-| 4.5MB 초과 | 백엔드 직접 호출 필요 |
+## 스토리지 구현 상세
 
-큰 파일이 필요하면 향후 **S3 presigned URL 전략** 도입을 검토해야 합니다.
+서버는 `STORAGE_TYPE` 환경변수로 스토리지 구현체를 전환합니다.
+
+| 환경 | `STORAGE_TYPE` | 저장 위치 |
+|------|--------------|---------|
+| 로컬 개발 | `local` | 서버 로컬 파일시스템 (`/uploads`) |
+| 프로덕션 | `gcs` | Google Cloud Storage 버킷 |
+
+> 프로덕션에서는 GCS 버킷(`GCS_BUCKET_NAME`)에 저장되고, `PUBLIC_BASE_URL` 환경변수로 설정된 public URL이 반환됩니다.
+
+### 이미지 검증 (서버)
+
+- **허용 Content-Type**: `image/jpeg`, `image/png`, `image/webp`, `image/gif`, `application/json`
+- **최대 픽셀 수**: 50 megapixels (초과 시 거부)
+- **Magic Bytes 검증**: Content-Type 위조 방지 — 파일 헤더로 실제 형식 확인
+
+### 캘린더 이미지 제한
+
+- 이벤트당 최대 **10장**
+- 초과 시 `imageUrls`에 담아도 무시됨
+
+---
+
+## ⚠️ Vercel 프록시 4.5MB 제한
+
+웹 클라이언트가 `/api/[...path]` 프록시를 통해 업로드하면 **Vercel Route Handler의 4.5MB body 제한**에 걸립니다.
+
+```
+클라이언트 → Vercel Route Handler → 백엔드
+                 ↑ 4.5MB 제한
+```
+
+| 파일 크기 | 해결 방법 |
+|----------|---------|
+| 4.5MB 이하 | 프록시 통해 정상 동작 |
+| 4.5MB 초과 | 백엔드 직접 호출 또는 S3 Presigned URL 전략 필요 |
+
+### 향후 개선: Presigned URL 방식
+
+```
+1. 클라이언트 → 서버: 업로드 URL 요청
+2. 서버 → 클라이언트: GCS Presigned URL 반환
+3. 클라이언트 → GCS: 직접 업로드 (Vercel 거치지 않음)
+4. 클라이언트 → 서버: 업로드된 URL로 게시글 작성
+```
+
+현재 미구현 — 대용량 파일 지원 시 도입 검토 필요.

--- a/docs-site/content/docs/guide/file-upload.mdx
+++ b/docs-site/content/docs/guide/file-upload.mdx
@@ -1,0 +1,44 @@
+---
+title: 파일 업로드
+description: 이미지 및 JSON 파일 업로드 제한사항
+---
+
+## 엔드포인트
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| POST | `/files/image` | 이미지 업로드 |
+| POST | `/files/json` | 교육 콘텐츠 JSON 업로드 |
+| POST | `/users/me/profile-image` | 프로필 이미지 업로드 |
+
+모두 `multipart/form-data` 형식입니다.
+
+```
+/files/image         → form-data key: "file"
+/files/json          → form-data key: "file"
+/users/me/profile-image → form-data key: "image"
+```
+
+## 응답
+
+```json
+{
+  "data": {
+    "url": "https://...",
+    "filename": "image.jpg",
+    "size": 204800,
+    "contentType": "image/jpeg"
+  }
+}
+```
+
+## ⚠️ Vercel 프록시 제한
+
+Vercel Route Handler 프록시를 통해 업로드하면 **4.5MB** 제한이 있습니다.
+
+| 파일 크기 | 방법 |
+|----------|------|
+| 4.5MB 이하 | Vercel 프록시 통해 정상 업로드 |
+| 4.5MB 초과 | 백엔드 직접 호출 필요 |
+
+큰 파일이 필요하면 향후 **S3 presigned URL 전략** 도입을 검토해야 합니다.

--- a/docs-site/content/docs/guide/meta.json
+++ b/docs-site/content/docs/guide/meta.json
@@ -1,0 +1,4 @@
+{
+  "title": "연동 가이드",
+  "pages": ["authentication", "community", "calendar", "file-upload", "notifications"]
+}

--- a/docs-site/content/docs/guide/notifications.mdx
+++ b/docs-site/content/docs/guide/notifications.mdx
@@ -1,31 +1,68 @@
 ---
 title: 알림
-description: 알림 조회 및 읽음 처리
+description: 알림 구현 방식 및 폴링 전략
 ---
 
 ## 엔드포인트
 
 | 메서드 | 경로 | 설명 |
 |--------|------|------|
-| GET | `/notifications` | 알림 목록 |
+| GET | `/notifications?page=1&size=20` | 알림 목록 |
 | GET | `/notifications/unread-count` | 읽지 않은 알림 수 |
 | PATCH | `/notifications/{id}/read` | 단건 읽음 처리 |
 | PATCH | `/notifications/read-all` | 전체 읽음 처리 |
 
-### 목록 파라미터
+## 알림 타입
 
+서버에 정의된 `NotificationType`:
+
+| 타입 | 발생 조건 |
+|------|---------|
+| `NEW_COMMENT` | 내 게시글에 댓글 달림 |
+| `COMMENT_LIKED` | 내 댓글에 좋아요 |
+| `SYSTEM` | 시스템 공지 |
+
+응답 예시:
+```json
+{
+  "data": [
+    {
+      "id": 1,
+      "type": "NEW_COMMENT",
+      "title": "새 댓글",
+      "body": "홍길동님이 댓글을 남겼습니다.",
+      "isRead": false,
+      "createdAt": "2024-01-01T12:00:00"
+    }
+  ]
+}
 ```
-GET /notifications?page=1&size=20
-```
 
-## 실시간 알림 전략
+---
 
-> ⚠️ 서버에 SSE/WebSocket이 없습니다. **폴링 방식**으로 구현해야 합니다.
+## ⚠️ 실시간 알림 없음 — 폴링 방식
+
+서버에 **SSE(Server-Sent Events)나 WebSocket이 없습니다.**
+알림 뱃지는 `/notifications/unread-count`를 주기적으로 폴링해서 구현해야 합니다.
 
 ```ts
-// 예시: 30초마다 미확인 알림 수 체크
-setInterval(async () => {
-  const count = await api.notifications.unreadCount()
-  setUnreadCount(count)
-}, 30_000)
+// 권장: 30초 간격 폴링
+useEffect(() => {
+  const fetch = async () => {
+    const count = await api.notifications.unreadCount()
+    setUnreadCount(count.data)
+  }
+  fetch()
+  const id = setInterval(fetch, 30_000)
+  return () => clearInterval(id)
+}, [])
 ```
+
+> 향후 사용자가 많아지면 SSE 또는 WebSocket으로 전환하는 것을 검토해야 합니다.
+
+---
+
+## 알림 생성 시점
+
+현재 알림은 서버 내부에서 직접 `NotificationRepository.save()`로 생성합니다.
+별도의 이벤트 시스템 없이 서비스 레이어에서 직접 저장하는 방식입니다.

--- a/docs-site/content/docs/guide/notifications.mdx
+++ b/docs-site/content/docs/guide/notifications.mdx
@@ -1,0 +1,31 @@
+---
+title: 알림
+description: 알림 조회 및 읽음 처리
+---
+
+## 엔드포인트
+
+| 메서드 | 경로 | 설명 |
+|--------|------|------|
+| GET | `/notifications` | 알림 목록 |
+| GET | `/notifications/unread-count` | 읽지 않은 알림 수 |
+| PATCH | `/notifications/{id}/read` | 단건 읽음 처리 |
+| PATCH | `/notifications/read-all` | 전체 읽음 처리 |
+
+### 목록 파라미터
+
+```
+GET /notifications?page=1&size=20
+```
+
+## 실시간 알림 전략
+
+> ⚠️ 서버에 SSE/WebSocket이 없습니다. **폴링 방식**으로 구현해야 합니다.
+
+```ts
+// 예시: 30초마다 미확인 알림 수 체크
+setInterval(async () => {
+  const count = await api.notifications.unreadCount()
+  setUnreadCount(count)
+}, 30_000)
+```

--- a/docs-site/content/docs/index.mdx
+++ b/docs-site/content/docs/index.mdx
@@ -1,8 +1,44 @@
 ---
 title: 별도리 API 문서
-description: 별도리 백엔드 서버 API 레퍼런스
+description: 별도리 백엔드 서버 API 레퍼런스 및 연동 가이드
 ---
 
 별도리 백엔드 API 문서에 오신 것을 환영합니다.
 
-API 레퍼런스는 사이드바의 **API Reference** 섹션에서 확인할 수 있습니다.
+## Base URL
+
+```
+https://byeoldori-server-hbxnfn4woa-du.a.run.app
+```
+
+> **웹에서는** Vercel 프록시 `/api/[...path]`를 통해 호출합니다. CORS 우회 및 백엔드 URL 차폐 목적입니다.
+
+## 공통 응답 구조
+
+모든 API는 아래 형식으로 응답합니다.
+
+```json
+{
+  "success": true,
+  "message": "OK",
+  "data": { ... }
+}
+```
+
+## 인증
+
+보호된 API는 모두 `Authorization` 헤더가 필요합니다.
+
+```
+Authorization: Bearer {accessToken}
+```
+
+| 응답 코드 | 의미 |
+|----------|------|
+| `401` | 미인증 — 토큰 없거나 만료 |
+| `403` | 권한 없음 |
+
+## 문서 구성
+
+- **[연동 가이드](/docs/guide/authentication)** — 인증 플로우, 파일 업로드 제한, 알림 폴링 등 실전 가이드
+- **[API Reference](/docs/api)** — OpenAPI 자동 생성 전체 엔드포인트 목록

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "별도리 API",
-  "pages": ["index", "api"]
+  "pages": ["index", "guide", "api"]
 }


### PR DESCRIPTION
## Summary

Fumadocs 문서 사이트에 백엔드 연동 가이드 MDX 추가

## 추가된 문서

```
docs/
├── index.mdx                    — Base URL, 공통 응답 구조
└── guide/
    ├── authentication.mdx       — 인증 플로우 + 구현 상세
    ├── community.mdx            — 게시글/댓글/좋아요 + 구현 상세
    ├── calendar.mdx             — 관측 일정 CRUD + 구현 상세
    ├── file-upload.mdx          — 업로드 제한 + GCS/로컬 전환
    └── notifications.mdx        — 알림 폴링 전략
```

## 주요 내용

| 가이드 | 핵심 내용 |
|--------|---------|
| 인증 | JWT HMAC-SHA256, 리프레시 토큰 SHA-256 해시 저장, Rate Limit 규칙 |
| 커뮤니티 | FULLTEXT 검색, 이미지 첨부 플로우, 미구현 항목 |
| 캘린더 | 상태값, 완료 처리, 월별 요약 응답 구조 |
| 파일 업로드 | Vercel 4.5MB 제한, Magic Bytes 검증, Presigned URL 전략 |
| 알림 | NotificationType, 폴링 코드 예시 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)