### PR TITLE
fix: fumadocs-openapi generateFiles API 수정

### DIFF
--- a/docs-site/scripts/generate-api.mjs
+++ b/docs-site/scripts/generate-api.mjs
@@ -1,9 +1,13 @@
 import { generateFiles } from 'fumadocs-openapi';
+import { createOpenAPI } from 'fumadocs-openapi/server';
+
+const openapi = createOpenAPI({
+  input: ['./openapi.json'],
+});
 
 await generateFiles({
-  input: ['./openapi.json'],
+  input: openapi,
   output: './content/docs/api',
-  groupBy: 'tag',
 });
 
 console.log('API docs generated from openapi.json');


### PR DESCRIPTION
## 원인

`fumadocs-openapi` v10에서 `generateFiles`의 `input`이 파일 경로 배열이 아닌 `getSchemas()` 메서드를 가진 객체를 요구함

## 수정

```js
// 이전 (에러)
input: ['./openapi.json']

// 이후 (수정)
import { createOpenAPI } from 'fumadocs-openapi/server';
const openapi = createOpenAPI({ input: ['./openapi.json'] });
input: openapi
```

로컬 테스트 완료 — MDX 파일 정상 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)