### PR TITLE
fix: WeatherApiHealthIndicator 503 문제 수정

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/forecast/config/WeatherApiHealthIndicator.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/config/WeatherApiHealthIndicator.kt
@@ -19,12 +19,13 @@ class WeatherApiHealthIndicator(
         val shortCount = shortGridForecastService.getDataCount()
         val midCount   = midCombinedForecastService.count()
 
-        val builder = if (ultraCount > 0 && shortCount > 0) Health.up() else Health.down()
-
-        return builder
+        // 날씨 데이터 적재 여부는 정보성 — 배포 헬스체크에 영향 주지 않음
+        return Health.up()
             .withDetail("ultra_forecast_slots", ultraCount)
             .withDetail("short_forecast_slots", shortCount)
             .withDetail("mid_forecast_rows",    midCount)
+            .withDetail("ultra_loaded",  ultraCount > 0)
+            .withDetail("short_loaded",  shortCount > 0)
             .build()
     }
 }


### PR DESCRIPTION
## 원인

날씨 데이터 미적재 시 `WeatherApiHealthIndicator`가 `DOWN` 반환 → `/actuator/health` 503 → 배포 자동 롤백

## 수정

`Health.down()` → `Health.up()` (항상 UP)
데이터 적재 여부는 `ultra_loaded`, `short_loaded` detail로만 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)