### PR TITLE
feat: getAllSites 응답에 averageScore 추가

### DIFF
--- a/docs-site/content/docs/guide/meta.json
+++ b/docs-site/content/docs/guide/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "연동 가이드",
-  "pages": ["authentication", "community", "calendar", "file-upload", "forecast"]
+  "pages": ["authentication", "community", "calendar", "file-upload", "forecast", "observation-sites"]
 }

--- a/docs-site/content/docs/guide/observation-sites.mdx
+++ b/docs-site/content/docs/guide/observation-sites.mdx
@@ -1,0 +1,201 @@
+---
+title: 관측지
+description: 관측지 목록 조회, 검색, 즐겨찾기 연동 가이드
+---
+
+## 엔드포인트 요약
+
+| 메서드 | 경로 | 설명 | 인증 필요 |
+|--------|------|------|----------|
+| GET | `/observationsites` | 관측지 목록 (페이지네이션) | ❌ |
+| GET | `/observationsites/{id}` | 관측지 상세 조회 | ❌ |
+| GET | `/observationsites/name?keyword=` | 관측지 이름 검색 | ❌ |
+| POST | `/me/saved-sites/toggle` | 즐겨찾기 토글 | ✅ |
+| GET | `/me/saved-sites` | 저장된 관측지 목록 | ✅ |
+| DELETE | `/me/saved-sites/{savedSiteId}` | 즐겨찾기 삭제 | ✅ |
+
+---
+
+## 관측지 목록 조회
+
+```
+GET /observationsites?page={페이지}&size={개수}
+```
+
+기본값: `size=20`, `name` 기준 오름차순 정렬.
+
+### 응답
+
+```json
+{
+  "content": [
+    {
+      "id": 1,
+      "name": "별마로 천문대",
+      "latitude": 37.1978,
+      "longitude": 128.4865,
+      "averageScore": 4.3
+    },
+    {
+      "id": 2,
+      "name": "소백산 천문대",
+      "latitude": 36.9397,
+      "longitude": 128.4858,
+      "averageScore": null
+    }
+  ],
+  "totalElements": 42,
+  "totalPages": 3,
+  "number": 0,
+  "size": 20
+}
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `id` | Long | 관측지 ID |
+| `name` | String | 관측지 이름 |
+| `latitude` | Double | 위도 |
+| `longitude` | Double | 경도 |
+| `averageScore` | Double? | 평균 평점 (리뷰 없으면 `null`) |
+
+> `averageScore`는 해당 관측지에 등록된 후기(ReviewPost)의 평균 점수(소수점 1자리)입니다.
+> 리뷰가 없는 관측지는 `null`로 반환됩니다.
+
+---
+
+## 관측지 상세 조회
+
+```
+GET /observationsites/{id}
+```
+
+### 응답
+
+```json
+{
+  "success": true,
+  "message": "OK",
+  "data": {
+    "id": 1,
+    "name": "별마로 천문대",
+    "latitude": 37.1978,
+    "longitude": 128.4865,
+    "reviewCount": 12,
+    "totalLikes": 34,
+    "averageScore": 4.3
+  }
+}
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `reviewCount` | Long | 후기 게시글 수 |
+| `totalLikes` | Long | 관련 게시글 총 좋아요 수 |
+| `averageScore` | Double | 평균 평점 (리뷰 없으면 `0.0`) |
+
+---
+
+## 관측지 이름 검색
+
+```
+GET /observationsites/name?keyword={검색어}
+```
+
+- 2자 이상: FULLTEXT 검색
+- 1자: LIKE fallback
+
+### 응답
+
+```json
+[
+  {
+    "id": 1,
+    "name": "별마로 천문대",
+    "latitude": 37.1978,
+    "longitude": 128.4865,
+    "averageScore": 4.3
+  }
+]
+```
+
+---
+
+## 즐겨찾기 토글
+
+공식 관측지 또는 임의 좌표를 즐겨찾기에 추가/해제합니다.
+
+```
+POST /me/saved-sites/toggle
+Authorization: Bearer {accessToken}
+```
+
+### 공식 관측지 즐겨찾기
+
+```json
+{
+  "siteId": 1
+}
+```
+
+### 임의 장소 즐겨찾기
+
+```json
+{
+  "name": "내가 찾은 명당",
+  "latitude": 37.1234,
+  "longitude": 127.5678
+}
+```
+
+### 응답
+
+```json
+{
+  "isSaved": true,
+  "savedSiteId": 42
+}
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `isSaved` | Boolean | 최종 즐겨찾기 상태 (true: 추가, false: 해제) |
+| `savedSiteId` | Long? | 즐겨찾기 항목 ID (추가된 경우에만 반환) |
+
+---
+
+## 저장된 관측지 목록
+
+```
+GET /me/saved-sites
+Authorization: Bearer {accessToken}
+```
+
+### 응답
+
+```json
+[
+  {
+    "savedSiteId": 42,
+    "siteId": 1,
+    "name": "별마로 천문대",
+    "latitude": 37.1978,
+    "longitude": 128.4865,
+    "isCustom": false
+  },
+  {
+    "savedSiteId": 43,
+    "siteId": null,
+    "name": "내가 찾은 명당",
+    "latitude": 37.1234,
+    "longitude": 127.5678,
+    "isCustom": true
+  }
+]
+```
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `savedSiteId` | Long | 즐겨찾기 항목 ID |
+| `siteId` | Long? | 공식 관측지 ID (`isCustom=true`이면 `null`) |
+| `isCustom` | Boolean | 임의 저장 여부 |

--- a/src/main/kotlin/com/project/byeoldori/community/post/repository/ReviewPostRepository.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/post/repository/ReviewPostRepository.kt
@@ -13,4 +13,12 @@ interface ReviewPostRepository : JpaRepository<ReviewPost, Long> {
 
     @Query("SELECT r.id, r.observationSite.id FROM ReviewPost r WHERE r.id IN :postIds AND r.observationSite.id IS NOT NULL")
     fun findObservationSiteIdsByPostIds(@Param("postIds") postIds: List<Long>): List<Array<Any>>
+
+    @Query("""
+        SELECT r.observationSite.id, ROUND(AVG(r.score), 1)
+        FROM ReviewPost r
+        WHERE r.observationSite.id IN :siteIds AND r.score IS NOT NULL
+        GROUP BY r.observationSite.id
+    """)
+    fun findAverageScoresBySiteIds(@Param("siteIds") siteIds: List<Long>): List<Array<Any>>
 }

--- a/src/main/kotlin/com/project/byeoldori/observationsites/dto/ObservationSiteDto.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/dto/ObservationSiteDto.kt
@@ -64,7 +64,8 @@ data class ObservationSiteResponseDto(
     val id: Long,
     val name: String,
     val latitude: Double,
-    val longitude: Double
+    val longitude: Double,
+    val averageScore: Double? = null
 )
 
 // DTO ➔ Entity 변환
@@ -76,7 +77,7 @@ fun ObservationSiteDto.toEntity(): ObservationSite {
     )
 }
 
-// Entity ➔ 응답 DTO 변환
+// Entity ➔ 응답 DTO 변환 (생성/수정용 - averageScore 불필요)
 fun ObservationSite.toResponseDto() = ObservationSiteResponseDto(
     id = this.id,
     name = this.name,

--- a/src/main/kotlin/com/project/byeoldori/observationsites/service/ObservationSiteService.kt
+++ b/src/main/kotlin/com/project/byeoldori/observationsites/service/ObservationSiteService.kt
@@ -30,8 +30,22 @@ class ObservationSiteService(
 
     // 모든 관측지 조회 (페이지네이션)
     @Transactional(readOnly = true)
-    fun getAllSites(pageable: Pageable): Page<ObservationSiteResponseDto> =
-        observationSiteRepository.findAll(pageable).map { it.toResponseDto() }
+    fun getAllSites(pageable: Pageable): Page<ObservationSiteResponseDto> {
+        val sitePage = observationSiteRepository.findAll(pageable)
+        val siteIds = sitePage.content.map { it.id }
+        val scoreMap: Map<Long, Double> = if (siteIds.isEmpty()) emptyMap()
+        else reviewPostRepository.findAverageScoresBySiteIds(siteIds)
+            .associate { row -> (row[0] as Long) to (row[1] as Double) }
+        return sitePage.map { site ->
+            ObservationSiteResponseDto(
+                id = site.id,
+                name = site.name,
+                latitude = site.latitude,
+                longitude = site.longitude,
+                averageScore = scoreMap[site.id]
+            )
+        }
+    }
 
     // 관측지 검색 (FULLTEXT, 2자 미만 키워드는 LIKE fallback)
     @Transactional(readOnly = true)


### PR DESCRIPTION
## Summary
- `GET /observationsites` 응답에 `averageScore(Double?)` 필드 추가
- 리뷰가 없는 관측지는 `null` 반환, 있으면 소수점 1자리 평균값 반환
- N+1 방지: 페이지 단위 siteId 목록을 한 번의 GROUP BY 쿼리로 일괄 조회
- `observation-sites.mdx` 가이드 문서 신규 작성

## Test plan
- [ ] `GET /observationsites` 응답에 `averageScore` 필드 존재 확인
- [ ] 리뷰 있는 관측지: `averageScore` 숫자값 반환
- [ ] 리뷰 없는 관측지: `averageScore: null` 반환
- [ ] Swagger UI 스키마에 `averageScore` 반영 확인
- [ ] 배포 후 문서 사이트에 "관측지" 가이드 노출 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)