### PR TITLE
fix: 초단기/단기 예보 tmef별 실패 격리 및 에러 핸들러 추가

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/forecast/service/ShortGridForecastService.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/service/ShortGridForecastService.kt
@@ -131,7 +131,11 @@ class ShortGridForecastService(
             .concatMap { tmef ->
                 fetchShortGrid(tmfc, tmef)
                     .map { grid -> Pair(tmef, grid) }
-                    .delayElement(Duration.ofMillis(100)) // 각 요청 사이에 100ms 딜레이를 줍니다.
+                    .onErrorResume { e ->
+                        logger.error("단기 tmef=$tmef 로드 실패, 건너뜀: ${e.message}")
+                        Mono.empty()
+                    }
+                    .delayElement(Duration.ofMillis(100))
             }
             .collectList()
     }
@@ -143,15 +147,18 @@ class ShortGridForecastService(
 
     fun updateAllShortTMEFData(tmfc: String, tmefList: List<String>) {
         fetchShortGrids(tmfc, tmefList)
-            .subscribe { listOfGrids ->
-                shortReadWriteLock.write {
-                    shortTMEFGridMap.clear()
-                    listOfGrids.forEach { (tmef, grid) ->
-                        shortTMEFGridMap[tmef] = grid
+            .subscribe(
+                { listOfGrids ->
+                    shortReadWriteLock.write {
+                        shortTMEFGridMap.clear()
+                        listOfGrids.forEach { (tmef, grid) ->
+                            shortTMEFGridMap[tmef] = grid
+                        }
                     }
-                }
-                logger.info("모든 short tmef 데이터 업데이트 완료. 결과 개수: ${listOfGrids.size}")
-            }
+                    logger.info("모든 short tmef 데이터 업데이트 완료. 결과 개수: ${listOfGrids.size}")
+                },
+                { e -> logger.error("단기 전체 데이터 업데이트 실패", e) }
+            )
     }
 
     /**

--- a/src/main/kotlin/com/project/byeoldori/forecast/service/UltraGridForecastService.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/service/UltraGridForecastService.kt
@@ -6,6 +6,7 @@ import com.project.byeoldori.forecast.utils.forecasts.ForecastElement
 import com.project.byeoldori.forecast.utils.forecasts.GridDataParser
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
@@ -102,12 +103,14 @@ class UltraGridForecastService(
         tmefList: List<String>
     ): Mono<List<Pair<String, MutableList<MutableList<UltraGridCell>>>>> {
         val monoList = tmefList.map { tmef ->
-            fetchUltraShortGrid(tmfc, tmef).map { grid -> Pair(tmef, grid) }
+            fetchUltraShortGrid(tmfc, tmef)
+                .map { grid -> Pair(tmef, grid) }
+                .onErrorResume { e ->
+                    logger.error("초단기 tmef=$tmef 로드 실패, 건너뜀: ${e.message}")
+                    Mono.empty()
+                }
         }
-
-        return Mono.zip(monoList) { arrayOfResults ->
-            arrayOfResults.map { it as Pair<String, MutableList<MutableList<UltraGridCell>>> }
-        }
+        return Flux.merge(monoList).collectList()
     }
 
     /**
@@ -117,15 +120,18 @@ class UltraGridForecastService(
 
     fun updateAllUltraTMEFData(tmfc: String, tmefList: List<String>) {
         fetchUltraShortGrids(tmfc, tmefList)
-            .subscribe { listOfGrids ->
-                ultraReadWriteLock.write {
-                    ultraTMEFGridMap.clear()
-                    listOfGrids.forEach { (tmef, grid) ->
-                        ultraTMEFGridMap[tmef] = grid
+            .subscribe(
+                { listOfGrids ->
+                    ultraReadWriteLock.write {
+                        ultraTMEFGridMap.clear()
+                        listOfGrids.forEach { (tmef, grid) ->
+                            ultraTMEFGridMap[tmef] = grid
+                        }
                     }
-                }
-                logger.info("모든 tmef 데이터 업데이트 완료. 결과 개수: ${listOfGrids.size}")
-            }
+                    logger.info("모든 tmef 데이터 업데이트 완료. 결과 개수: ${listOfGrids.size}")
+                },
+                { e -> logger.error("초단기 전체 데이터 업데이트 실패", e) }
+            )
     }
 
 


### PR DESCRIPTION
## Summary
- 단기 예보(`shortForecastResponse`)가 빈 배열로 반환되는 버그 수정
- tmef 하나 실패 시 이후 전체 데이터가 누락되던 문제 해결
- 에러 로그 추가로 실패 원인 추적 가능해짐

## 원인
- `fetchUltraShortGrids`: `Mono.zip`은 하나라도 실패하면 전체 실패
- `fetchShortGrids`: `concatMap` 중 하나 실패 시 이후 tmef 전부 스킵
- `subscribe()`에 에러 핸들러 없어 실패가 조용히 무시됨

## Test plan
- [ ] 배포 후 Cloud Run 로그에서 단기예보 데이터 로드 건수 확인
- [ ] `/weather/ForecastData` 응답에 `shortForecastResponse` 데이터 존재 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)