### PR TITLE
perf: 단기예보 tmef 병렬 처리 (concatMap → flatMap)

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/forecast/service/ShortGridForecastService.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/service/ShortGridForecastService.kt
@@ -11,7 +11,6 @@ import reactor.core.publisher.Mono
 import java.util.concurrent.locks.ReentrantReadWriteLock
 import kotlin.concurrent.read
 import kotlin.concurrent.write
-import java.time.Duration
 import kotlin.math.max
 
 // 단일 격자 셀 구조 (ShortGridCell)
@@ -128,15 +127,14 @@ class ShortGridForecastService(
         tmefList: List<String>
     ): Mono<List<Pair<String, MutableList<MutableList<ShortGridCell>>>>> {
         return Flux.fromIterable(tmefList)
-            .concatMap { tmef ->
+            .flatMap({ tmef ->
                 fetchShortGrid(tmfc, tmef)
                     .map { grid -> Pair(tmef, grid) }
                     .onErrorResume { e ->
                         logger.error("단기 tmef=$tmef 로드 실패, 건너뜀: ${e.message}")
                         Mono.empty()
                     }
-                    .delayElement(Duration.ofMillis(100))
-            }
+            }, 5)
             .collectList()
     }
 

--- a/src/main/kotlin/com/project/byeoldori/forecast/utils/forecasts/ForecastTimeUtil.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/utils/forecasts/ForecastTimeUtil.kt
@@ -5,7 +5,8 @@ import java.time.format.DateTimeFormatter
 
 object ForecastTimeUtil {
 
-    private val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmm")
+    private val formatter = DateTimeFormatter.ofPattern("yyyyMMddHHmm")      // 초단기 tmfc용 (분 포함)
+    private val shortFormatter = DateTimeFormatter.ofPattern("yyyyMMddHH")   // 단기 tmfc/tmef용 (분 없음)
 
     /**
      * 초단기예보에서 유효한 발표시각(tmfc)을 계산
@@ -49,7 +50,7 @@ object ForecastTimeUtil {
         }
 
         // 3) 포맷팅하여 반환
-        return dateTime.format(formatter)
+        return dateTime.format(shortFormatter)
     }
 
     fun getTMEFTimesForShortForecast(): List<String> {
@@ -95,6 +96,6 @@ object ForecastTimeUtil {
             temp = temp.plusHours(1)
         }
 
-        return result.map { it.format(formatter) }
+        return result.map { it.format(shortFormatter) }
     }
 }


### PR DESCRIPTION
## 문제

PR #102에서 tmfc 형식이 수정되어 단기예보 API가 정상 호출됨을 확인.
그러나 `concatMap`으로 73개 tmef를 순차 처리하여 전체 로딩에 최대 36분 소요.

## 변경

`fetchShortGrids`의 `concatMap` → `flatMap(concurrency=5)`:
- tmef 5개 동시 처리 → 전체 시간 약 1/5로 단축
- `onErrorResume`으로 개별 tmef 실패 격리 유지
- 불필요한 `delayElement(100ms)` 제거

| 방식 | 73 tmef 예상 소요 시간 |
|---|---|
| concatMap (이전) | ~36분 |
| flatMap(5) (이후) | ~7분 |