### PR TITLE
refactor(docs): API 플레이그라운드 기존 가이드 문서에 인라인 통합

### DIFF
--- a/docs-site/content/docs/guide/authentication.mdx
+++ b/docs-site/content/docs/guide/authentication.mdx
@@ -153,3 +153,10 @@ POST /users/logout   (Authorization 헤더 필요)
 |------|----------|----------|
 | AuthGuard 리다이렉트 | 제거됨 | 미로그인 시 `/login`으로 이동 복구 |
 | 세션 만료 UX | `window.location.href='/login'` | `router.push('/login')`으로 교체 |
+
+---
+
+## API 직접 테스트
+
+<APIPage document="openapi" operations={[{"path":"/auth/signup","method":"post"},{"path":"/auth/login","method":"post"},{"path":"/auth/token","method":"post"},{"path":"/auth/find-email","method":"post"},{"path":"/auth/password/reset-request","method":"post"},{"path":"/auth/password/reset-confirm","method":"post"},{"path":"/auth/google","method":"post"},{"path":"/auth/verify-email","method":"get"},{"path":"/users/logout","method":"post"}]} showTitle />
+

--- a/docs-site/content/docs/guide/calendar.mdx
+++ b/docs-site/content/docs/guide/calendar.mdx
@@ -92,3 +92,9 @@ GET /calendar/events/month?year=2024&month=1
 - 날짜/시간은 **초/나노초를 0으로 정규화**해서 저장합니다. (`2024-01-15T20:00:00`)
 - `startAt`이 `endAt`보다 늦으면 `400 Bad Request`
 - 이벤트 삭제 시 첨부 이미지도 스토리지에서 삭제됩니다 (트랜잭션 커밋 후)
+
+---
+
+## API 직접 테스트
+
+<APIPage document="openapi" operations={[{"path":"/calendar/events","method":"post"},{"path":"/calendar/events/month","method":"get"},{"path":"/calendar/events/date","method":"get"},{"path":"/calendar/events/count","method":"get"},{"path":"/calendar/events/{id}","method":"get"},{"path":"/calendar/events/{id}","method":"patch"},{"path":"/calendar/events/{id}","method":"delete"},{"path":"/calendar/events/{id}/complete","method":"post"}]} showTitle />

--- a/docs-site/content/docs/guide/community.mdx
+++ b/docs-site/content/docs/guide/community.mdx
@@ -143,3 +143,9 @@ POST /community/posts/{id}/comments/{cid}/likes-toggle  — 댓글 좋아요
 - **내가 쓴 글 목록** — 서버 엔드포인트 없음, 구현 전 서버 작업 필요
 - **내가 좋아요한 글 목록** — 서버 엔드포인트 없음
 - **교육 콘텐츠 평가 조회** — 작성은 가능하나 내 평가 조회 API 없음
+
+---
+
+## API 직접 테스트
+
+<APIPage document="openapi" operations={[{"path":"/community/{type}/posts","method":"get"},{"path":"/community/{type}/posts","method":"post"},{"path":"/community/posts/{postId}","method":"get"},{"path":"/community/posts/{postId}","method":"patch"},{"path":"/community/posts/{postId}","method":"delete"},{"path":"/community/posts/{postId}/likes/toggle","method":"post"},{"path":"/community/posts/{postId}/evaluations","method":"post"},{"path":"/community/posts/{postId}/comments","method":"get"},{"path":"/community/posts/{postId}/comments","method":"post"},{"path":"/community/posts/{postId}/comments/{commentId}","method":"patch"},{"path":"/community/posts/{postId}/comments/{commentId}","method":"delete"},{"path":"/community/posts/{postId}/comments/{commentId}/likes-toggle","method":"post"},{"path":"/community/home/free-posts","method":"get"},{"path":"/community/home/reviews","method":"get"},{"path":"/community/home/educations","method":"get"}]} showTitle />

--- a/docs-site/content/docs/guide/file-upload.mdx
+++ b/docs-site/content/docs/guide/file-upload.mdx
@@ -78,3 +78,9 @@ description: 이미지 및 JSON 파일 업로드 — 구현 상세와 제한사�
 ```
 
 현재 미구현 — 대용량 파일 지원 시 도입 검토 필요.
+
+---
+
+## API 직접 테스트
+
+<APIPage document="openapi" operations={[{"path":"/files/image","method":"post"},{"path":"/files/json","method":"post"}]} showTitle />

--- a/docs-site/content/docs/guide/forecast.mdx
+++ b/docs-site/content/docs/guide/forecast.mdx
@@ -198,3 +198,9 @@ GET /weather/summary?lat={위도}&lon={경도}
 | 중기 | 06:10 / 18:10 | 기상청 중기 예보 발표 주기 |
 
 API 호출 실패 시 설정된 횟수만큼 자동 재시도합니다.
+
+---
+
+## API 직접 테스트
+
+<APIPage document="openapi" operations={[{"path":"/weather/ForecastData","method":"get"},{"path":"/weather/summary","method":"get"}]} showTitle />

--- a/docs-site/content/docs/guide/observation-sites.mdx
+++ b/docs-site/content/docs/guide/observation-sites.mdx
@@ -199,3 +199,9 @@ Authorization: Bearer {accessToken}
 | `savedSiteId` | Long | 즐겨찾기 항목 ID |
 | `siteId` | Long? | 공식 관측지 ID (`isCustom=true`이면 `null`) |
 | `isCustom` | Boolean | 임의 저장 여부 |
+
+---
+
+## API 직접 테스트
+
+<APIPage document="openapi" operations={[{"path":"/observationsites","method":"get"},{"path":"/observationsites/name","method":"get"},{"path":"/observationsites/{id}","method":"get"},{"path":"/observationsites","method":"post"},{"path":"/observationsites/{id}","method":"put"},{"path":"/observationsites/{id}","method":"delete"},{"path":"/me/saved-sites","method":"get"},{"path":"/me/saved-sites/toggle","method":"post"},{"path":"/me/saved-sites/{savedSiteId}","method":"get"},{"path":"/me/saved-sites/{savedSiteId}","method":"delete"}]} showTitle />

--- a/docs-site/content/docs/meta.json
+++ b/docs-site/content/docs/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "별도리 API",
-  "pages": ["index", "guide", "api"]
+  "pages": ["index", "guide"]
 }

--- a/docs-site/scripts/generate-api.mjs
+++ b/docs-site/scripts/generate-api.mjs
@@ -1,30 +1,11 @@
-import { copyFileSync, mkdirSync, rmSync } from 'fs';
+import { copyFileSync, mkdirSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { createOpenAPI } from 'fumadocs-openapi/server';
-import { generateFiles } from 'fumadocs-openapi';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const src = resolve(__dirname, '../openapi.json');
-
-// public/에 복사 (Scalar 등 다른 도구용 fallback)
 const dest = resolve(__dirname, '../public/openapi.json');
+
 mkdirSync(dirname(dest), { recursive: true });
 copyFileSync(src, dest);
 console.log('openapi.json → public/openapi.json 복사 완료');
-
-// 기존 생성 파일 초기화
-const apiOutputDir = resolve(__dirname, '../content/docs/api');
-rmSync(apiOutputDir, { recursive: true, force: true });
-
-// tag별 MDX 생성
-const openapi = createOpenAPI({ input: [src] });
-
-await generateFiles({
-  input: openapi,
-  output: apiOutputDir,
-  per: 'tag',
-  meta: true,
-});
-
-console.log('API Reference MDX 생성 완료 →', apiOutputDir);

--- a/docs-site/src/lib/openapi.ts
+++ b/docs-site/src/lib/openapi.ts
@@ -1,9 +1,9 @@
+import openapiSpec from '../../openapi.json';
 import { createOpenAPI } from 'fumadocs-openapi/server';
 import { createAPIPage } from 'fumadocs-openapi/ui';
-import path from 'path';
 
 export const openapi = createOpenAPI({
-  input: [path.resolve(process.cwd(), 'openapi.json')],
+  input: () => ({ openapi: openapiSpec as never }),
 });
 
 export const APIPage = createAPIPage(openapi);


### PR DESCRIPTION
## Summary

- PR #105의 별도 `/docs/api/*` 페이지 방식을 폐기하고, 기존 가이드 문서 하단에 직접 Try It 패널 삽입
- `createOpenAPI`를 고정 키(`"openapi"`) 방식으로 변경해 환경 무관하게 동작
- `generate-api.mjs`를 단순 복사 스크립트로 복원

## 변경된 파일

| 파일 | 추가된 API 엔드포인트 수 |
|------|----------------------|
| `guide/forecast.mdx` | 2개 (`/weather/ForecastData`, `/weather/summary`) |
| `guide/authentication.mdx` | 9개 (회원가입/로그인/토큰 등) |
| `guide/observation-sites.mdx` | 10개 (관측지 CRUD + 즐겨찾기) |
| `guide/community.mdx` | 15개 (게시글/댓글/좋아요 등) |
| `guide/calendar.mdx` | 8개 (이벤트 CRUD) |
| `guide/file-upload.mdx` | 2개 (이미지/JSON 업로드) |

## Test plan

- [ ] `npm run build` 성공 확인
- [ ] 배포 후 `/docs/guide/forecast` 하단에 Try It 패널 표시 확인
- [ ] 실제 API 호출 동작 확인 (`GET /weather/summary`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)