### PR TITLE
fix(security): CORS preflight OPTIONS 요청 허용

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
@@ -8,6 +8,7 @@ import jakarta.servlet.http.HttpServletResponse
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.MediaType
+import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
@@ -68,10 +69,9 @@ class SecurityConfig(
             }
             .authorizeHttpRequests { authorize ->
                 authorize
-                    // 위에서 정의한 PUBLIC_URLS 경로들은 인증 없이 허용
+                    // CORS preflight
+                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                     .requestMatchers(*PUBLIC_URLS).permitAll()
-
-                    // 그 외의 모든 요청은 반드시 인증(로그인)을 요구
                     .anyRequest().authenticated()
             }
             .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter::class.java)


### PR DESCRIPTION
## Summary

- Spring Security가 `OPTIONS` preflight 요청을 인증 필터에서 차단해 docs 플레이그라운드 Try It 호출 시 403 오류 발생
- `HttpMethod.OPTIONS, "/**"` 를 permitAll로 추가해 CORS preflight 허용

## 원인

`CORS_ALLOWED_ORIGINS` 에 `byeoldori-docs.pages.dev` 를 추가했음에도 불구하고, Spring Security의 `.authorizeHttpRequests` 가 OPTIONS를 authenticated() 로 평가해 403 반환

## Test plan

- [ ] 배포 후 docs 플레이그라운드 `GET /weather/summary` Try It → 200 확인
- [ ] 기존 인증 보호 엔드포인트 (`POST /community/posts`) 토큰 없이 → 401 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)