### PR TITLE
fix(security): CORS allowedOrigins Kotlin 스코핑 버그 수정

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
@@ -83,8 +83,9 @@ class SecurityConfig(
     //프론트엔드가 분리되어 있을 경우 사용
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
+        val origins = allowedOrigins
         val configuration = CorsConfiguration().apply {
-            allowedOrigins = allowedOrigins
+            allowedOrigins = origins
             allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             allowedHeaders = listOf("*")
             allowCredentials = true


### PR DESCRIPTION
## 원인

\`CorsConfiguration().apply { allowedOrigins = allowedOrigins }\` 에서
\`apply\` 블록의 \`this\`는 \`CorsConfiguration\` 이므로,
우변의 \`allowedOrigins\` 도 \`CorsConfiguration.allowedOrigins\` (null) 를 참조.
결과적으로 허용 Origin이 null → 모든 요청에 403 반환.

## 수정

\`val origins = allowedOrigins\` 로 클래스 필드를 먼저 캡처한 뒤 \`apply\` 블록에서 사용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)