### PR TITLE
feat: 날씨 엔드포인트 비인증 공개 처리

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
@@ -35,6 +35,7 @@ class SecurityConfig(
             "/auth/**",
             "/reset-password",
             "/actuator/health",
+            "/weather/**",
         )
     }
 


### PR DESCRIPTION
## Summary
- `/weather/**` 전체를 PUBLIC_URLS에 추가 → 비로그인 사용자도 날씨 조회 가능
- 대상: `/weather/ForecastData`, `/weather/live`, `/weather/summary`

## 배경
프론트엔드에서 비로그인 시 401 → 예보 전체 미표시 문제 발생.
날씨 데이터는 로그인 없이 공개되어야 하는 데이터.

## Test plan
- [ ] 비로그인 상태에서 `GET /weather/ForecastData?lat=37.5&lon=127.0` → 200 확인
- [ ] 비로그인 상태에서 `GET /weather/live?lat=37.5&lon=127.0` → 200 확인
- [ ] 비로그인 상태에서 `GET /weather/summary?lat=37.5&lon=127.0` → 200 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)