### PR TITLE
fix: 단기 tmef DateTimeParseException 수정

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/forecast/utils/score/WeatherScoreCalculator.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/utils/score/WeatherScoreCalculator.kt
@@ -184,7 +184,8 @@ class WeatherScoreCalculator (
     // ─────────────────────────────
 
     private fun parseTime(tmef: String): LocalDateTime =
-        LocalDateTime.parse(tmef, tmefFmt)
+        if (tmef.length == 10) LocalDateTime.parse("${tmef}00", tmefFmt)
+        else LocalDateTime.parse(tmef, tmefFmt)
 
     private fun parseMidTime(tmEf: String): LocalDateTime =
         if (tmEf.length == 12) LocalDateTime.parse(tmEf, tmefFmt)


### PR DESCRIPTION
## 원인
단기예보 tmef는 `yyyyMMddHH`(10자리) 포맷으로 저장되는데,
`WeatherScoreCalculator.parseTime()`은 `yyyyMMddHHmm`(12자리)를 기대.

→ 단기 데이터 로드 후 `suitabilityForShort()` 최초 호출 시 `DateTimeParseException` 발생
→ `/weather/ForecastData` 전체가 500 반환 (Unhandled Exception)

## 증상
- 서버 기동 직후(단기 메모리 비어있을 때)는 200 빈 배열 반환
- 단기 데이터 로드 완료 후 호출 시 500 오류

## 수정
10자리 tmef에 `"00"` suffix를 붙여 12자리로 맞춘 후 파싱

🤖 Generated with [Claude Code](https://claude.com/claude-code)