### PR TITLE
perf: WebClient 응답 타임아웃 명시적 설정 (60s)

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/forecast/config/WebClientConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/config/WebClientConfig.kt
@@ -1,19 +1,29 @@
 package com.project.byeoldori.forecast.config
 
+import io.netty.channel.ChannelOption
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.client.reactive.ReactorClientHttpConnector
 import org.springframework.web.reactive.function.client.WebClient
+import reactor.netty.http.client.HttpClient
+import java.time.Duration
+
 
 @Configuration
 class WebClientConfig {
     @Bean
     fun weatherApiClient(): WebClient {
+        val httpClient = HttpClient.create()
+            .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 10_000)   // TCP 연결 10s
+            .responseTimeout(Duration.ofSeconds(60))                  // 응답 수신 60s (격자 340KB 고려)
+
         return WebClient.builder()
+            .clientConnector(ReactorClientHttpConnector(httpClient))
             .baseUrl("https://apihub.kma.go.kr/api/typ01")
             .defaultHeader("Content-Type", "application/json")
             .codecs { configurer ->
                 configurer.defaultCodecs().maxInMemorySize(524288)
-            } // Data 512kb 까지 전송받을수있게 설정, 기상청 격자데이터가 약 340kb임
+            }
             .build()
     }
 


### PR DESCRIPTION
## 변경
KMA API WebClient에 명시적 타임아웃 설정 추가

- TCP 연결 타임아웃: 10s
- 응답 수신 타임아웃: 60s (기존 미설정 → 무한대)

## 효과
기상청 격자 데이터(340KB) 수신 시 응답 지연에 대한 명확한 제한 설정

🤖 Generated with [Claude Code](https://claude.com/claude-code)