### PR TITLE
fix: OAuth 신규 유저 생성 시 nickname/email 제약 위반 수정

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/user/service/UserService.kt
+++ b/src/main/kotlin/com/project/byeoldori/user/service/UserService.kt
@@ -416,12 +416,13 @@ class UserService(
         }
 
         if (user == null) {
+            val effectiveEmail = if (email.isBlank()) "$provider.$providerId@noemail.byeoldori" else email
             user = User(
-                email = email,
+                email = effectiveEmail,
                 passwordHash = "OAUTH2:$provider:$providerId",
                 name = name ?: "User",
                 phone = "",
-                nickname = name
+                nickname = null
             )
         }
 


### PR DESCRIPTION
## 문제

소셜 로그인(카카오/네이버/구글) 후 즉시 로그아웃되는 버그

## 원인

`findOrCreateOAuthUser()`에서 신규 OAuth 유저를 생성할 때 두 가지 DB 제약 위반 발생:

1. **nickname UNIQUE 위반**: `nickname = name`으로 설정 시, 동일한 닉네임을 가진 유저가 이미 존재하면 `DataIntegrityViolationException` (500) 발생 → 트랜잭션 롤백 → JWT 미발급 → 프론트 구 토큰으로 `/users/me` 호출 → 401 → 로그아웃
2. **email UNIQUE 위반**: 카카오 이메일 권한 미동의 유저의 경우 `email = ""`로 저장되는데, 두 번째 이런 유저가 가입하면 빈 문자열 email이 충돌 → 500 에러

## 수정 내용

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| nickname | `nickname = name` | `nickname = null` (사용자가 온보딩에서 직접 설정) |
| 이메일 없는 OAuth 유저 | `email = ""` | `email = "$provider.$providerId@noemail.byeoldori"` (synthetic email) |

## 테스트 포인트

- 카카오 신규 가입 → 정상 JWT 발급 → `/users/me` 200 OK
- 동일 닉네임 보유자가 있는 상태에서 소셜 로그인 신규 가입 → 정상 동작
- 이메일 미동의 카카오 유저 재로그인 시 providerId로 기존 유저 조회 → 정상 동작