### PR TITLE
refresh 토큰 httpOnly 쿠키화 (안드로이드 호환)

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/security/JwtUtil.kt
+++ b/src/main/kotlin/com/project/byeoldori/security/JwtUtil.kt
@@ -22,6 +22,10 @@ class JwtUtil(
 ) {
     val zoneId: ZoneId = ZoneId.of("Asia/Seoul")
 
+    // Refresh 토큰 TTL(초). httpOnly refreshToken 쿠키의 Max-Age 파생에 사용.
+    val refreshTokenTtlSeconds: Long
+        get() = refreshExpMs / 1000
+
     private val key: SecretKey = Keys.hmacShaKeyFor(
         MessageDigest.getInstance("SHA-256").digest(secret.toByteArray(StandardCharsets.UTF_8))
     )

--- a/src/main/kotlin/com/project/byeoldori/user/controller/AuthController.kt
+++ b/src/main/kotlin/com/project/byeoldori/user/controller/AuthController.kt
@@ -1,18 +1,43 @@
 package com.project.byeoldori.user.controller
 
+import com.project.byeoldori.common.exception.ErrorCode
+import com.project.byeoldori.common.exception.UnauthorizedException
 import com.project.byeoldori.common.web.ApiResponse
+import com.project.byeoldori.security.JwtUtil
 import com.project.byeoldori.user.dto.*
 import com.project.byeoldori.user.service.UserService
 import io.swagger.v3.oas.annotations.Operation
+import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
+import java.time.Duration
 
 @RestController
 @RequestMapping("/auth")
 class AuthController(
-    private val userService: UserService
+    private val userService: UserService,
+    private val jwt: JwtUtil
 ) {
+
+    private companion object {
+        const val REFRESH_COOKIE = "refreshToken"
+    }
+
+    // refresh 토큰을 httpOnly 쿠키로 내려준다(웹 XSS 완화). body 토큰은 그대로 유지(안드로이드 호환).
+    // Domain 속성은 절대 넣지 않는다(프론트가 다른 도메인 + 프록시 경유라 host-only 여야 함).
+    private fun addRefreshCookie(response: HttpServletResponse, refreshToken: String) {
+        val cookie = ResponseCookie.from(REFRESH_COOKIE, refreshToken)
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(Duration.ofSeconds(jwt.refreshTokenTtlSeconds))
+            .build()
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString())
+    }
 
     @PostMapping("/signup")
     @Operation(summary = "회원가입")
@@ -38,15 +63,29 @@ class AuthController(
 
     @PostMapping("/login")
     @Operation(summary = "로그인")
-    fun login(@Valid @RequestBody req: LoginRequestDto): ResponseEntity<ApiResponse<AuthResponseDto>> {
+    fun login(
+        @Valid @RequestBody req: LoginRequestDto,
+        response: HttpServletResponse
+    ): ResponseEntity<ApiResponse<AuthResponseDto>> {
         val auth: AuthResponseDto = userService.login(req)
+        addRefreshCookie(response, auth.refreshToken)
         return ResponseEntity.ok(ApiResponse.ok(auth))
     }
 
     @PostMapping("/token")
     @Operation(summary = "토큰 재발급")
-    fun reissue(@Valid @RequestBody req: TokenReissueRequestDto): ResponseEntity<ApiResponse<AuthResponseDto>> {
-        val auth: AuthResponseDto = userService.reissue(req)
+    fun reissue(
+        @CookieValue(name = REFRESH_COOKIE, required = false) cookieRefresh: String?,
+        @RequestBody(required = false) body: TokenReissueRequestDto?,
+        response: HttpServletResponse
+    ): ResponseEntity<ApiResponse<AuthResponseDto>> {
+        // 웹: httpOnly 쿠키 우선. 안드로이드: 쿠키가 없으면 기존 body 사용.
+        val refreshToken = cookieRefresh?.takeIf { it.isNotBlank() }
+            ?: body?.refreshToken?.takeIf { it.isNotBlank() }
+            ?: throw UnauthorizedException(ErrorCode.INVALID_TOKEN.message)
+
+        val auth: AuthResponseDto = userService.reissue(refreshToken)
+        addRefreshCookie(response, auth.refreshToken)
         return ResponseEntity.ok(ApiResponse.ok(auth))
     }
 
@@ -66,22 +105,34 @@ class AuthController(
 
     @PostMapping("/google")
     @Operation(summary = "Google 소셜 로그인", description = "프론트에서 받은 Authorization Code로 Google 로그인 처리 후 JWT를 발급합니다.")
-    fun loginWithGoogle(@RequestBody req: GoogleLoginRequest): ResponseEntity<ApiResponse<AuthResponseDto>> {
+    fun loginWithGoogle(
+        @RequestBody req: GoogleLoginRequest,
+        response: HttpServletResponse
+    ): ResponseEntity<ApiResponse<AuthResponseDto>> {
         val tokens = userService.loginWithGoogle(req.code, req.redirectUri)
+        addRefreshCookie(response, tokens.refreshToken)
         return ResponseEntity.ok(ApiResponse.ok(tokens))
     }
 
     @PostMapping("/kakao")
     @Operation(summary = "Kakao 소셜 로그인", description = "프론트에서 받은 Authorization Code로 Kakao 로그인 처리 후 JWT를 발급합니다.")
-    fun loginWithKakao(@RequestBody req: KakaoLoginRequest): ResponseEntity<ApiResponse<AuthResponseDto>> {
+    fun loginWithKakao(
+        @RequestBody req: KakaoLoginRequest,
+        response: HttpServletResponse
+    ): ResponseEntity<ApiResponse<AuthResponseDto>> {
         val tokens = userService.loginWithKakao(req.code, req.redirectUri)
+        addRefreshCookie(response, tokens.refreshToken)
         return ResponseEntity.ok(ApiResponse.ok(tokens))
     }
 
     @PostMapping("/naver")
     @Operation(summary = "Naver 소셜 로그인", description = "프론트에서 받은 Authorization Code로 Naver 로그인 처리 후 JWT를 발급합니다.")
-    fun loginWithNaver(@RequestBody req: NaverLoginRequest): ResponseEntity<ApiResponse<AuthResponseDto>> {
+    fun loginWithNaver(
+        @RequestBody req: NaverLoginRequest,
+        response: HttpServletResponse
+    ): ResponseEntity<ApiResponse<AuthResponseDto>> {
         val tokens = userService.loginWithNaver(req.code, req.redirectUri)
+        addRefreshCookie(response, tokens.refreshToken)
         return ResponseEntity.ok(ApiResponse.ok(tokens))
     }
 }

--- a/src/main/kotlin/com/project/byeoldori/user/controller/UserController.kt
+++ b/src/main/kotlin/com/project/byeoldori/user/controller/UserController.kt
@@ -4,8 +4,11 @@ import com.project.byeoldori.common.web.ApiResponse
 import com.project.byeoldori.user.dto.*
 import com.project.byeoldori.user.service.UserService
 import io.swagger.v3.oas.annotations.Operation
+import jakarta.servlet.http.HttpServletResponse
 import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
 import org.springframework.web.multipart.MultipartFile
@@ -39,8 +42,17 @@ class UserController(
 
     @PostMapping("/logout")
     @Operation(summary = "로그아웃 (리프레시 토큰 제거)")
-    fun logout(): ResponseEntity<ApiResponse<Unit>> {
+    fun logout(response: HttpServletResponse): ResponseEntity<ApiResponse<Unit>> {
         userService.logout()
+        // 웹: httpOnly refreshToken 쿠키를 즉시 만료(Max-Age=0). Domain 미지정(host-only), 발급 시 속성과 동일하게.
+        val expired = ResponseCookie.from("refreshToken", "")
+            .httpOnly(true)
+            .secure(true)
+            .sameSite("Lax")
+            .path("/")
+            .maxAge(0)
+            .build()
+        response.addHeader(HttpHeaders.SET_COOKIE, expired.toString())
         return ResponseEntity.ok(ApiResponse.ok("로그아웃 완료"))
     }
 

--- a/src/main/kotlin/com/project/byeoldori/user/service/UserService.kt
+++ b/src/main/kotlin/com/project/byeoldori/user/service/UserService.kt
@@ -106,18 +106,18 @@ class UserService(
     }
 
     @Transactional
-    fun reissue(req: TokenReissueRequestDto): AuthResponseDto {
-        if (!jwt.validateToken(req.refreshToken) || !jwt.isTokenType(req.refreshToken, "refresh")) {
+    fun reissue(refreshToken: String): AuthResponseDto {
+        if (!jwt.validateToken(refreshToken) || !jwt.isTokenType(refreshToken, "refresh")) {
             throw UnauthorizedException(ErrorCode.INVALID_TOKEN.message)
         }
-        val email = jwt.extractEmail(req.refreshToken)
+        val email = jwt.extractEmail(refreshToken)
         val user = userRepository.findByEmail(email)
             .orElseThrow { NotFoundException(ErrorCode.USER_NOT_FOUND) }
 
         val stored = refreshTokenRepo.findByUserIdForUpdate(user.id)
             .orElseThrow { NotFoundException(ErrorCode.REFRESH_TOKEN_NOT_FOUND) }
 
-        if (stored.tokenHash != TokenHasher.sha256Hex(req.refreshToken)) {
+        if (stored.tokenHash != TokenHasher.sha256Hex(refreshToken)) {
             throw UnauthorizedException("리프레시 토큰이 일치하지 않습니다.")
         }
 


### PR DESCRIPTION
**⚠️ 웹 PR과 lockstep + 보안(JWT/인증) 코드 변경.**  통과.

login/social/reissue 응답에 refresh 토큰 httpOnly 쿠키(Domain 없음, SameSite=Lax) 추가. reissue는 쿠키 우선·body 폴백. **body 토큰 유지로 안드로이드 앱 무영향.** logout이 쿠키 만료.

🧪 배포 후 **웹 로그인 1회 테스트 필수**(OAuth 자동검증 불가).

🤖 Generated with [Claude Code](https://claude.com/claude-code)