### PR TITLE
예보 캐시 견고화 + 순수 유닛테스트

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/forecast/scheduler/GridForecastScheduler.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/scheduler/GridForecastScheduler.kt
@@ -49,7 +49,6 @@ class GridForecastScheduler(
             fetchFunction = {
                 val tmfc = ForecastTimeUtil.getStableLiveTmfc()
                 liveGridForecastService.updateLiveData(tmfc)
-                Mono.empty()
             }
         )
     }
@@ -66,7 +65,6 @@ class GridForecastScheduler(
                 val tmfc = ForecastTimeUtil.getStableUltraTmfc()  // ← 60분 전 기준 안정적 tmfc
                 val tmefList = ForecastTimeUtil.getNext6UltraTmef()
                 ultraGridForecastService.updateAllUltraTMEFData(tmfc, tmefList)
-                Mono.empty()
             }
         )
     }
@@ -80,7 +78,6 @@ class GridForecastScheduler(
             tag = "단기예보",
             fetchFunction = {
                 shortGridForecastService.updateAllShortTMEFData(getTMFCTimeForShort(), getTMEFTimesForShortForecast())
-                Mono.empty()
             }
         )
     }

--- a/src/main/kotlin/com/project/byeoldori/forecast/service/LiveGridForecastService.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/service/LiveGridForecastService.kt
@@ -7,9 +7,6 @@ import com.project.byeoldori.forecast.utils.forecasts.GridDataParser
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
-import java.util.concurrent.locks.ReentrantReadWriteLock
-import kotlin.concurrent.read
-import kotlin.concurrent.write
 import kotlin.math.abs
 
 data class LiveGridCell(
@@ -30,11 +27,16 @@ class LiveGridForecastService(
     private val weatherData: WeatherData
 ) {
     private val logger = LoggerFactory.getLogger(this::class.java)
+    // 갱신 시 새 격자를 완성한 뒤 참조를 원자적으로 교체(@Volatile). 읽기는 현재 참조를 그대로 사용.
+    @Volatile
     private var liveGrid: MutableList<MutableList<LiveGridCell>> = mutableListOf()
-    private val lock = ReentrantReadWriteLock()
 
-    fun updateLiveData(tmfc: String) {
-        Mono.zip(
+    /**
+     * 완료를 기다릴 수 있도록 Mono<Void>를 반환한다(호출자가 성공/실패를 관찰·재시도 가능).
+     * 결과가 비면 기존 캐시를 보존한다.
+     */
+    fun updateLiveData(tmfc: String): Mono<Void> {
+        return Mono.zip(
             weatherData.fetchLiveWeather(tmfc, ForecastElement.T1H),
             weatherData.fetchLiveWeather(tmfc, ForecastElement.VEC),
             weatherData.fetchLiveWeather(tmfc, ForecastElement.WSD),
@@ -52,23 +54,24 @@ class LiveGridForecastService(
                 GridDataParser.parseGridData(t.t6),
                 GridDataParser.parseGridData(t.t7),
             )
-        }.subscribe(
-            { grid ->
-                lock.write { liveGrid = grid }
-                logger.info("실황 격자 데이터 업데이트 완료 (tmfc=$tmfc)")
-            },
-            { e -> logger.error("실황 격자 데이터 업데이트 실패", e) }
-        )
+        }.doOnNext { grid ->
+            if (grid.isEmpty() || grid[0].isEmpty()) {
+                logger.warn("실황 격자 데이터가 비어 있어 기존 캐시를 유지합니다. (tmfc=$tmfc)")
+                return@doOnNext
+            }
+            liveGrid = grid  // 원자적 참조 교체
+            logger.info("실황 격자 데이터 업데이트 완료 (tmfc=$tmfc)")
+        }.doOnError { e ->
+            logger.error("실황 격자 데이터 업데이트 실패", e)
+        }.then()
     }
 
     fun getLiveDataForCell(x: Int, y: Int): LiveForecastResponseDTO? {
-        return lock.read {
-            val cell = findNearest(x, y) ?: return@read null
-            LiveForecastResponseDTO(
-                t1h = cell.t1h, vec = cell.vec, wsd = cell.wsd,
-                pty = cell.pty, rn1 = cell.rn1, reh = cell.reh, sky = cell.sky
-            )
-        }
+        val cell = findNearest(x, y) ?: return null
+        return LiveForecastResponseDTO(
+            t1h = cell.t1h, vec = cell.vec, wsd = cell.wsd,
+            pty = cell.pty, rn1 = cell.rn1, reh = cell.reh, sky = cell.sky
+        )
     }
 
     private fun findNearest(x: Int, y: Int, maxRadius: Int = 5): LiveGridCell? {

--- a/src/main/kotlin/com/project/byeoldori/forecast/service/ShortGridForecastService.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/service/ShortGridForecastService.kt
@@ -8,9 +8,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import java.util.concurrent.locks.ReentrantReadWriteLock
-import kotlin.concurrent.read
-import kotlin.concurrent.write
 import kotlin.math.max
 
 // 단일 격자 셀 구조 (ShortGridCell)
@@ -46,9 +43,9 @@ class ShortGridForecastService(
      * tmef -> 2차원 ShortGridCell 매핑
      * 여러 tmef에 대한 격자를 저장해둠
      */
-    private val shortTMEFGridMap = mutableMapOf<String, MutableList<MutableList<ShortGridCell>>>()
-    // ReadWriteLock을 사용해 읽기와 쓰기를 분리
-    private val shortReadWriteLock = ReentrantReadWriteLock()
+    // 불변 스냅샷을 @Volatile 참조로 보관 → 갱신 시 새 Map을 만들어 참조만 한 번에 교체(원자적 swap)
+    @Volatile
+    private var shortTMEFGridMap: Map<String, MutableList<MutableList<ShortGridCell>>> = emptyMap()
     private val logger = LoggerFactory.getLogger(this::class.java)
 
     /**
@@ -141,22 +138,26 @@ class ShortGridForecastService(
     /**
      * 상위 레벨에서 모든 데이터를 수집한 후, 일괄 업데이트하는 메서드
      */
-    fun getDataCount(): Int = shortReadWriteLock.read { shortTMEFGridMap.size }
+    fun getDataCount(): Int = shortTMEFGridMap.size
 
-    fun updateAllShortTMEFData(tmfc: String, tmefList: List<String>) {
-        fetchShortGrids(tmfc, tmefList)
-            .subscribe(
-                { listOfGrids ->
-                    shortReadWriteLock.write {
-                        shortTMEFGridMap.clear()
-                        listOfGrids.forEach { (tmef, grid) ->
-                            shortTMEFGridMap[tmef] = grid
-                        }
-                    }
-                    logger.info("모든 short tmef 데이터 업데이트 완료. 결과 개수: ${listOfGrids.size}")
-                },
-                { e -> logger.error("단기 전체 데이터 업데이트 실패", e) }
-            )
+    /**
+     * 완료를 기다릴 수 있도록 Mono<Void>를 반환한다(호출자가 성공/실패를 관찰·재시도 가능).
+     * 갱신은 새 Map을 완성한 뒤 참조를 원자적으로 교체하며, 결과가 비면 기존 캐시를 보존한다.
+     */
+    fun updateAllShortTMEFData(tmfc: String, tmefList: List<String>): Mono<Void> {
+        return fetchShortGrids(tmfc, tmefList)
+            .doOnNext { listOfGrids ->
+                if (listOfGrids.isEmpty()) {
+                    logger.warn("단기 전체 데이터가 비어 있어 기존 캐시를 유지합니다.")
+                    return@doOnNext
+                }
+                val newMap = LinkedHashMap<String, MutableList<MutableList<ShortGridCell>>>(listOfGrids.size)
+                listOfGrids.forEach { (tmef, grid) -> newMap[tmef] = grid }
+                shortTMEFGridMap = newMap  // 원자적 참조 교체
+                logger.info("모든 short tmef 데이터 업데이트 완료. 결과 개수: ${listOfGrids.size}")
+            }
+            .doOnError { e -> logger.error("단기 전체 데이터 업데이트 실패", e) }
+            .then()
     }
 
     /**
@@ -164,33 +165,32 @@ class ShortGridForecastService(
      * 조회 작업은 readLock을 사용하여 여러 스레드가 동시에 접근 가능하도록 함
      */
     fun getAllShortTMEFDataForCell(x: Int, y: Int): List<ShortForecastResponseDTO> {
-        return shortReadWriteLock.read {
-            // 가장 가까운 유효 데이터를 찾는 로직 호출
-            val nearestCellData = findNearestDataForEachTmef(x, y)
+        // 가장 가까운 유효 데이터를 찾는 로직 호출
+        val nearestCellData = findNearestDataForEachTmef(x, y)
 
-            nearestCellData.map { (tmef, cell) ->
-                ShortForecastResponseDTO(
-                    tmef = tmef,
-                    tmp = cell.tmp,
-                    tmx = cell.tmx,
-                    tmn = cell.tmn,
-                    vec = cell.vec,
-                    wsd = cell.wsd,
-                    sky = cell.sky,
-                    pty = cell.pty,
-                    pcp = cell.pcp,
-                    pop = cell.pop,
-                    sno = cell.sno,
-                    reh = cell.reh
-                )
-            }.sortedBy { it.tmef }
-        }
+        return nearestCellData.map { (tmef, cell) ->
+            ShortForecastResponseDTO(
+                tmef = tmef,
+                tmp = cell.tmp,
+                tmx = cell.tmx,
+                tmn = cell.tmn,
+                vec = cell.vec,
+                wsd = cell.wsd,
+                sky = cell.sky,
+                pty = cell.pty,
+                pcp = cell.pcp,
+                pop = cell.pop,
+                sno = cell.sno,
+                reh = cell.reh
+            )
+        }.sortedBy { it.tmef }
     }
 
     private fun findNearestDataForEachTmef(x: Int, y: Int, maxRadius: Int = 5): List<Pair<String, ShortGridCell>> {
+        val snapshot = shortTMEFGridMap  // 현재 스냅샷을 한 번만 읽어 일관성 보장
         val results = mutableListOf<Pair<String, ShortGridCell>>()
 
-        for ((tmef, grid) in shortTMEFGridMap) {
+        for ((tmef, grid) in snapshot) {
             if (grid.isEmpty() || grid[0].isEmpty()) continue
 
             var foundCell: ShortGridCell? = null

--- a/src/main/kotlin/com/project/byeoldori/forecast/service/UltraGridForecastService.kt
+++ b/src/main/kotlin/com/project/byeoldori/forecast/service/UltraGridForecastService.kt
@@ -8,9 +8,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Flux
 import reactor.core.publisher.Mono
-import java.util.concurrent.locks.ReentrantReadWriteLock
-import kotlin.concurrent.read
-import kotlin.concurrent.write
 import kotlin.math.max
 
 // 단일 격자 셀 구조
@@ -40,9 +37,9 @@ class UltraGridForecastService(
      * 여러 tmef에 대한 격자를 저장해둠
      */
     private val logger = LoggerFactory.getLogger(this::class.java)
-    private val ultraTMEFGridMap = mutableMapOf<String, MutableList<MutableList<UltraGridCell>>>()
-    // 전역에 락 객체 정의 (업데이트 시에만 사용)
-    private val ultraReadWriteLock = ReentrantReadWriteLock()
+    // 불변 스냅샷을 @Volatile 참조로 보관 → 갱신 시 새 Map을 만들어 참조만 한 번에 교체(원자적 swap)
+    @Volatile
+    private var ultraTMEFGridMap: Map<String, MutableList<MutableList<UltraGridCell>>> = emptyMap()
 
     /**
      * (1) 단일 tmef에 대한 초단기예보 격자 데이터 가져오기
@@ -117,22 +114,26 @@ class UltraGridForecastService(
     /**
      * 상위 레벨에서 모든 데이터를 수집한 후, 일괄 업데이트하는 메서드
      */
-    fun getDataCount(): Int = ultraReadWriteLock.read { ultraTMEFGridMap.size }
+    fun getDataCount(): Int = ultraTMEFGridMap.size
 
-    fun updateAllUltraTMEFData(tmfc: String, tmefList: List<String>) {
-        fetchUltraShortGrids(tmfc, tmefList)
-            .subscribe(
-                { listOfGrids ->
-                    ultraReadWriteLock.write {
-                        ultraTMEFGridMap.clear()
-                        listOfGrids.forEach { (tmef, grid) ->
-                            ultraTMEFGridMap[tmef] = grid
-                        }
-                    }
-                    logger.info("모든 tmef 데이터 업데이트 완료. 결과 개수: ${listOfGrids.size}")
-                },
-                { e -> logger.error("초단기 전체 데이터 업데이트 실패", e) }
-            )
+    /**
+     * 완료를 기다릴 수 있도록 Mono<Void>를 반환한다(호출자가 성공/실패를 관찰·재시도 가능).
+     * 갱신은 새 Map을 완성한 뒤 참조를 원자적으로 교체하며, 결과가 비면 기존 캐시를 보존한다.
+     */
+    fun updateAllUltraTMEFData(tmfc: String, tmefList: List<String>): Mono<Void> {
+        return fetchUltraShortGrids(tmfc, tmefList)
+            .doOnNext { listOfGrids ->
+                if (listOfGrids.isEmpty()) {
+                    logger.warn("초단기 전체 데이터가 비어 있어 기존 캐시를 유지합니다.")
+                    return@doOnNext
+                }
+                val newMap = LinkedHashMap<String, MutableList<MutableList<UltraGridCell>>>(listOfGrids.size)
+                listOfGrids.forEach { (tmef, grid) -> newMap[tmef] = grid }
+                ultraTMEFGridMap = newMap  // 원자적 참조 교체
+                logger.info("모든 tmef 데이터 업데이트 완료. 결과 개수: ${listOfGrids.size}")
+            }
+            .doOnError { e -> logger.error("초단기 전체 데이터 업데이트 실패", e) }
+            .then()
     }
 
 
@@ -143,31 +144,30 @@ class UltraGridForecastService(
      * 조회 작업은 readLock을 사용하여 여러 스레드가 동시에 접근 가능하도록 함
      */
     fun getAllUltraTMEFDataForCell(x: Int, y: Int): List<UltraForecastResponseDTO> {
-        return ultraReadWriteLock.read {
-            // 가장 가까운 유효 데이터를 찾는 로직 호출
-            val nearestCellData = findNearestDataForEachTmef(x, y)
+        // 가장 가까운 유효 데이터를 찾는 로직 호출
+        val nearestCellData = findNearestDataForEachTmef(x, y)
 
-            nearestCellData.map { (tmef, cell) ->
-                UltraForecastResponseDTO(
-                    tmef = tmef,
-                    t1h = cell.t1h,
-                    vec = cell.vec,
-                    wsd = cell.wsd,
-                    pty = cell.pty,
-                    rn1 = cell.rn1,
-                    reh = cell.reh,
-                    sky = cell.sky
-                )
-            }.sortedBy { it.tmef }
-        }
+        return nearestCellData.map { (tmef, cell) ->
+            UltraForecastResponseDTO(
+                tmef = tmef,
+                t1h = cell.t1h,
+                vec = cell.vec,
+                wsd = cell.wsd,
+                pty = cell.pty,
+                rn1 = cell.rn1,
+                reh = cell.reh,
+                sky = cell.sky
+            )
+        }.sortedBy { it.tmef }
     }
 
     // 주변 탐색 로직 추가 -> 탐색 반경은 5칸(25km)
     private fun findNearestDataForEachTmef(x: Int, y: Int, maxRadius: Int = 5): List<Pair<String, UltraGridCell>> {
+        val snapshot = ultraTMEFGridMap  // 현재 스냅샷을 한 번만 읽어 일관성 보장
         val results = mutableListOf<Pair<String, UltraGridCell>>()
 
         // 모든 예보 시간(tmef)에 대해 각각 가장 가까운 데이터를 탐색
-        for ((tmef, grid) in ultraTMEFGridMap) {
+        for ((tmef, grid) in snapshot) {
             if (grid.isEmpty() || grid[0].isEmpty()) continue
 
             var foundCell: UltraGridCell? = null

--- a/src/test/kotlin/LatLonToGridTest.kt
+++ b/src/test/kotlin/LatLonToGridTest.kt
@@ -1,0 +1,63 @@
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+
+/**
+ * latLonToGrid 좌표→격자 변환 검증 (기상청 DFS Lambert Conformal Conic, 순수 함수).
+ * 기대 격자값은 소스에 명시된 상수(RE/GRID/SLAT/OLON/OLAT/XO/YO)로 결정되며,
+ * 잘 알려진 좌표에 대해 재현 계산한 값을 사용한다.
+ * latLonToGrid.kt 는 패키지 선언이 없어 디폴트 패키지에 속하므로 본 테스트도 디폴트 패키지에 둔다.
+ */
+class LatLonToGridTest {
+
+    @Test
+    fun `서울 좌표는 격자 60 127 로 변환된다`() {
+        assertThat(latLonToGrid(37.5665, 126.9780)).isEqualTo(Pair(60, 127))
+    }
+
+    @Test
+    fun `부산 좌표는 격자 98 76 로 변환된다`() {
+        assertThat(latLonToGrid(35.1796, 129.0756)).isEqualTo(Pair(98, 76))
+    }
+
+    @Test
+    fun `대전 좌표는 격자 67 100 로 변환된다`() {
+        assertThat(latLonToGrid(36.3504, 127.3845)).isEqualTo(Pair(67, 100))
+    }
+
+    @Test
+    fun `기준 위경도(OLAT 38, OLON 126)는 기준 격자(XO 43, YO 136)로 변환된다`() {
+        assertThat(latLonToGrid(38.0, 126.0)).isEqualTo(Pair(43, 136))
+    }
+
+    @Test
+    fun `NaN 위경도는 예외를 던진다`() {
+        assertThatThrownBy { latLonToGrid(Double.NaN, 126.0) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { latLonToGrid(37.5, Double.NaN) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `위도 범위를 벗어나면 예외를 던진다`() {
+        assertThatThrownBy { latLonToGrid(95.0, 126.0) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { latLonToGrid(-91.0, 126.0) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `경도 범위를 벗어나면 예외를 던진다`() {
+        assertThatThrownBy { latLonToGrid(37.5, 200.0) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+        assertThatThrownBy { latLonToGrid(37.5, -181.0) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `한국 밖의 유효 위경도는 격자 범위를 벗어나 예외를 던진다`() {
+        // 도쿄 부근 - 위경도 자체는 유효하나 KMA 격자(1..149, 1..253) 밖
+        assertThatThrownBy { latLonToGrid(0.0, 0.0) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/src/test/kotlin/com/project/byeoldori/common/exception/ErrorCodeTest.kt
+++ b/src/test/kotlin/com/project/byeoldori/common/exception/ErrorCodeTest.kt
@@ -1,0 +1,39 @@
+package com.project.byeoldori.common.exception
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+
+/**
+ * ErrorCode enum 무결성 검증 (순수, Spring 컨텍스트 불필요).
+ */
+class ErrorCodeTest {
+
+    @Test
+    fun `모든 코드는 비어있지 않은 메시지와 status를 가진다`() {
+        ErrorCode.entries.forEach { code ->
+            assertThat(code.message).`as`("%s 메시지", code.name).isNotBlank()
+            assertThat(code.status).`as`("%s status", code.name).isNotNull()
+        }
+    }
+
+    @Test
+    fun `특수 케이스 status 매핑이 유지된다`() {
+        assertThat(ErrorCode.OUT_OF_SERVICE_AREA.status).isEqualTo(HttpStatus.I_AM_A_TEAPOT)
+        assertThat(ErrorCode.FILE_TOO_LARGE.status).isEqualTo(HttpStatus.PAYLOAD_TOO_LARGE)
+        assertThat(ErrorCode.INTERNAL_SERVER_ERROR.status).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR)
+        assertThat(ErrorCode.UNAUTHORIZED.status).isEqualTo(HttpStatus.UNAUTHORIZED)
+        assertThat(ErrorCode.USER_NOT_FOUND.status).isEqualTo(HttpStatus.NOT_FOUND)
+    }
+
+    @Test
+    fun `enum 이름은 중복되지 않는다`() {
+        val names = ErrorCode.entries.map { it.name }
+        assertThat(names).doesNotHaveDuplicates()
+    }
+
+    @Test
+    fun `valueOf 로 상수를 되찾을 수 있다`() {
+        assertThat(ErrorCode.valueOf("USER_NOT_FOUND")).isEqualTo(ErrorCode.USER_NOT_FOUND)
+    }
+}

--- a/src/test/kotlin/com/project/byeoldori/common/web/ApiResponseTest.kt
+++ b/src/test/kotlin/com/project/byeoldori/common/web/ApiResponseTest.kt
@@ -1,0 +1,58 @@
+package com.project.byeoldori.common.web
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * ApiResponse 팩토리 메서드 검증 (순수 data class, Spring 컨텍스트 불필요).
+ */
+class ApiResponseTest {
+
+    @Test
+    fun `ok()는 기본 성공 응답을 만든다`() {
+        val res = ApiResponse.ok()
+
+        assertThat(res.success).isTrue()
+        assertThat(res.message).isEqualTo("OK")
+        assertThat(res.data).isNull()
+        assertThat(res.code).isNull()
+    }
+
+    @Test
+    fun `ok(message)는 메시지를 설정하고 데이터는 비운다`() {
+        val res = ApiResponse.ok("처리 완료")
+
+        assertThat(res.success).isTrue()
+        assertThat(res.message).isEqualTo("처리 완료")
+        assertThat(res.data).isNull()
+    }
+
+    @Test
+    fun `ok(data)는 데이터를 담은 성공 응답을 만든다`() {
+        val res = ApiResponse.ok(42)
+
+        assertThat(res.success).isTrue()
+        assertThat(res.message).isEqualTo("OK")
+        assertThat(res.data).isEqualTo(42)
+    }
+
+    @Test
+    fun `fail()은 실패 응답을 만들고 code를 담는다`() {
+        val res = ApiResponse.fail<String>("에러 발생", data = "detail", code = "E001")
+
+        assertThat(res.success).isFalse()
+        assertThat(res.message).isEqualTo("에러 발생")
+        assertThat(res.data).isEqualTo("detail")
+        assertThat(res.code).isEqualTo("E001")
+    }
+
+    @Test
+    fun `fail()의 data와 code는 기본적으로 null이다`() {
+        val res = ApiResponse.fail<Unit>("에러")
+
+        assertThat(res.success).isFalse()
+        assertThat(res.message).isEqualTo("에러")
+        assertThat(res.data).isNull()
+        assertThat(res.code).isNull()
+    }
+}

--- a/src/test/kotlin/com/project/byeoldori/forecast/utils/forecasts/GridDataParserTest.kt
+++ b/src/test/kotlin/com/project/byeoldori/forecast/utils/forecasts/GridDataParserTest.kt
@@ -1,0 +1,67 @@
+package com.project.byeoldori.forecast.utils.forecasts
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * GridDataParser 순수 파싱 로직 검증 (Spring 컨텍스트 불필요).
+ * 규칙: numCols 개씩 행 분할, 행 순서 반전, "-99" 접두 토큰은 null, 파싱 실패도 null.
+ */
+class GridDataParserTest {
+
+    @Test
+    fun `numCols 단위로 그룹화하고 행 순서를 반전한다`() {
+        // 토큰: [1,2,3,4] numCols=2 → 원본 [[1,2],[3,4]] → 반전 [[3,4],[1,2]]
+        val result = GridDataParser.parseGridData("1,2,3,4", numCols = 2)
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).containsExactly(3.0, 4.0)
+        assertThat(result[1]).containsExactly(1.0, 2.0)
+    }
+
+    @Test
+    fun `-99 접두 토큰은 null로 변환된다`() {
+        // [1.5, -99.00, 3, 4] numCols=2 → [[1.5,null],[3,4]] → 반전 [[3,4],[1.5,null]]
+        val result = GridDataParser.parseGridData("1.5,-99.00,3,4", numCols = 2)
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).containsExactly(3.0, 4.0)
+        assertThat(result[1]).containsExactly(1.5, null)
+    }
+
+    @Test
+    fun `공백은 트림되고 빈 토큰은 무시된다`() {
+        val result = GridDataParser.parseGridData(" 1 , 2 , , 3 , 4 ", numCols = 2)
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).containsExactly(3.0, 4.0)
+        assertThat(result[1]).containsExactly(1.0, 2.0)
+    }
+
+    @Test
+    fun `숫자로 변환할 수 없는 토큰은 null이 된다`() {
+        val result = GridDataParser.parseGridData("abc,2", numCols = 2)
+
+        assertThat(result).hasSize(1)
+        assertThat(result[0]).containsExactly(null, 2.0)
+    }
+
+    @Test
+    fun `행 수는 전체 토큰수를 numCols로 나눈 몫이며 나머지는 버려진다`() {
+        // 5개 토큰, numCols=2 → 2행(4토큰), 마지막 토큰은 버려짐
+        val result = GridDataParser.parseGridData("1,2,3,4,5", numCols = 2)
+
+        assertThat(result).hasSize(2)
+        assertThat(result.flatten()).containsExactly(3.0, 4.0, 1.0, 2.0)
+    }
+
+    @Test
+    fun `문자열 파서는 정확히 -99_00 만 null 처리하고 나머지는 원문을 유지한다`() {
+        // [A,-99.00,-99,B] numCols=2 → [[A,null],[-99,B]] → 반전 [[-99,B],[A,null]]
+        val result = GridDataParser.parseGridDataString("A,-99.00,-99,B", numCols = 2)
+
+        assertThat(result).hasSize(2)
+        assertThat(result[0]).containsExactly("-99", "B")
+        assertThat(result[1]).containsExactly("A", null)
+    }
+}


### PR DESCRIPTION
compileKotlin + 순수테스트 7종 GREEN. **VM 배포하여 weather 실동작 검증**(스케줄러 캐시 로딩→summary/ForecastData 정상 반환).

- 예보 격자 캐시: clear-then-fill → @Volatile 원자적 swap(갱신 중 빈/부분 노출 방지, fetch 실패 시 기존 보존)
- 스케줄러 fire-and-forget → Mono<Void> 완료관찰+실패 로깅
- weather 응답 형태·값·나선탐색 로직 불변
- 테스트: LatLonToGrid/GridDataParser/ErrorCode/ApiResponse
- Redis 공유캐시+shedlock은 멀티인스턴스 스케일 시 후속(단일 인스턴스라 현재 불필요)

🤖 Generated with [Claude Code](https://claude.com/claude-code)