### PR TITLE
deploy.yml 자동배포 트리거 비활성(실패 알림 중단)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,11 +1,8 @@
 name: Deploy backend
 
 on:
-  push:
-    branches: [ "main" ]
-    paths-ignore:
-      - "**/*.md"
-      - "docs/**"
+  # main push 자동배포는 비활성(SSH 시크릿 미설정 + VM은 arm64 소스빌드라 GHCR pull 불일치).
+  # 자동배포 필요 시: SSH_HOST/USER/KEY/DEPLOY_DIR 시크릿 설정 + arm64 빌드/소스전송 방식으로 전환 후 push 트리거 복구.
   workflow_dispatch: {}
 
 concurrency:


### PR DESCRIPTION
main push마다 SSH 배포 스텝 실패로 Discord 배포실패 알림이 반복돼서, 자동 트리거를 workflow_dispatch(수동)만 남김. 실제 배포는 기존처럼 수동(소스전송+VM빌드). 자동배포 원하면 별도 세팅 필요. 🤖 Generated with [Claude Code](https://claude.com/claude-code)