### PR TITLE
feat(edu): 교육 프로그램 MongoDB 도메인 + 시스템설정·어드민 게이트

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,6 +63,8 @@ jobs:
             printf 'DISCORD_WEBHOOK_URL=%s\nCF_API_TOKEN=%s\nCF_ACCOUNT_ID=%s\nCF_ACCOUNTS=%s\n' \
               "$DISCORD_WEBHOOK_BACKEND_URL" "$CLOUDFLARE_API_TOKEN" "$CLOUDFLARE_ACCOUNT_ID" "$CLOUDFLARE_ACCOUNT_ID" \
               > monitoring/secrets.env
+            # 교육 프로그램 저장용 MongoDB 기동(앱이 연결하므로 배포 전에). 이미 떠있으면 no-op.
+            docker compose -f docker-compose.oci.yml -f docker-compose.mongo.yml up -d mongo || true
             # 블루-그린 무중단 배포: 비활성 색을 빌드·기동→헬스 통과 시에만
             # nginx upstream 전환→구 색 정지. 실패하면 기존 컨테이너 유지.
             bash deploy-bluegreen.sh

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-cache")
     implementation("org.flywaydb:flyway-mysql")
     implementation("org.springframework.boot:spring-boot-starter-data-redis-reactive")
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/docker-compose.mongo.yml
+++ b/docker-compose.mongo.yml
@@ -1,0 +1,25 @@
+# 교육 프로그램 저장용 MongoDB (프로덕션 오버레이)
+# 로컬 compose.yml의 mongo를 프로덕션 기준으로: 포트 미노출(내부망 전용),
+# mem_limit, 비밀번호는 .env(MONGO_ROOT_PASSWORD)로 주입, backend 네트워크에서 app과 통신.
+# 기동: docker compose -f docker-compose.oci.yml -f docker-compose.mongo.yml up -d mongo
+services:
+  mongo:
+    image: mongo:6.0
+    container_name: mongodb
+    restart: always
+    mem_limit: 400m
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGO_ROOT_PASSWORD:-root}
+      MONGO_INITDB_DATABASE: byeoldori
+    volumes:
+      - mongo_data:/data/db
+    networks: [backend]
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.adminCommand('ping')"]
+      interval: 15s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  mongo_data:

--- a/src/main/kotlin/com/project/byeoldori/admin/controller/AdminController.kt
+++ b/src/main/kotlin/com/project/byeoldori/admin/controller/AdminController.kt
@@ -1,0 +1,43 @@
+package com.project.byeoldori.admin.controller
+
+import com.project.byeoldori.admin.dto.UpdateConfigRequest
+import com.project.byeoldori.admin.service.SystemConfigService
+import com.project.byeoldori.common.exception.ForbiddenException
+import com.project.byeoldori.common.web.ApiResponse
+import com.project.byeoldori.user.entity.User
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/admin")
+@Tag(name = "Admin", description = "관리자 전용 API")
+class AdminController(
+    private val systemConfigService: SystemConfigService
+) {
+    @GetMapping("/config")
+    @Operation(summary = "시스템 설정 전체 조회", description = "관리자 전용. 전역 설정 키-값 전체를 반환합니다.")
+    fun getConfig(
+        @RequestAttribute("currentUser") user: User
+    ): Map<String, String> {
+        requireAdmin(user)
+        return systemConfigService.getAll()
+    }
+
+    @PutMapping("/config")
+    @Operation(summary = "시스템 설정 변경", description = "관리자 전용. 지정한 키의 값을 설정합니다.")
+    fun updateConfig(
+        @Valid @RequestBody req: UpdateConfigRequest,
+        @RequestAttribute("currentUser") user: User
+    ): ResponseEntity<ApiResponse<Unit>> {
+        requireAdmin(user)
+        systemConfigService.set(req.key, req.value)
+        return ResponseEntity.ok(ApiResponse.ok("설정이 변경되었습니다."))
+    }
+
+    private fun requireAdmin(user: User) {
+        if (!user.roles.contains("ADMIN")) throw ForbiddenException("관리자 권한이 필요합니다.")
+    }
+}

--- a/src/main/kotlin/com/project/byeoldori/admin/domain/SystemConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/admin/domain/SystemConfig.kt
@@ -1,0 +1,21 @@
+package com.project.byeoldori.admin.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+
+/**
+ * 키-값 확장형 시스템 전역 설정 (MySQL).
+ * key/value 는 MySQL 예약어이므로 컬럼명은 config_key / config_value 로 매핑한다.
+ */
+@Entity
+@Table(name = "system_config")
+class SystemConfig(
+    @Id
+    @Column(name = "config_key", length = 128)
+    var key: String = "",
+
+    @Column(name = "config_value", length = 1024, nullable = false)
+    var value: String = ""
+)

--- a/src/main/kotlin/com/project/byeoldori/admin/dto/AdminDtos.kt
+++ b/src/main/kotlin/com/project/byeoldori/admin/dto/AdminDtos.kt
@@ -1,0 +1,9 @@
+package com.project.byeoldori.admin.dto
+
+import jakarta.validation.constraints.NotBlank
+
+data class UpdateConfigRequest(
+    @field:NotBlank(message = "설정 키는 필수입니다.")
+    val key: String,
+    val value: String
+)

--- a/src/main/kotlin/com/project/byeoldori/admin/repository/SystemConfigRepository.kt
+++ b/src/main/kotlin/com/project/byeoldori/admin/repository/SystemConfigRepository.kt
@@ -1,0 +1,6 @@
+package com.project.byeoldori.admin.repository
+
+import com.project.byeoldori.admin.domain.SystemConfig
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface SystemConfigRepository : JpaRepository<SystemConfig, String>

--- a/src/main/kotlin/com/project/byeoldori/admin/service/SystemConfigService.kt
+++ b/src/main/kotlin/com/project/byeoldori/admin/service/SystemConfigService.kt
@@ -1,0 +1,39 @@
+package com.project.byeoldori.admin.service
+
+import com.project.byeoldori.admin.domain.SystemConfig
+import com.project.byeoldori.admin.repository.SystemConfigRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class SystemConfigService(
+    private val repo: SystemConfigRepository
+) {
+    companion object {
+        const val MODERATION_REQUIRED = "moderation.required"
+    }
+
+    @Transactional(readOnly = true)
+    fun getBool(key: String, default: Boolean): Boolean {
+        val cfg = repo.findById(key).orElse(null) ?: return default
+        return cfg.value.trim().toBooleanStrictOrNull() ?: default
+    }
+
+    @Transactional
+    fun set(key: String, value: String) {
+        val cfg = repo.findById(key).orElse(null)
+        if (cfg != null) {
+            cfg.value = value
+        } else {
+            repo.save(SystemConfig(key = key, value = value))
+        }
+    }
+
+    @Transactional(readOnly = true)
+    fun getAll(): Map<String, String> =
+        repo.findAll().associate { it.key to it.value }
+
+    /** 발행 전 검수(moderation) 필요 여부. 미설정 시 기본 ON(true). */
+    @Transactional(readOnly = true)
+    fun moderationRequired(): Boolean = getBool(MODERATION_REQUIRED, true)
+}

--- a/src/main/kotlin/com/project/byeoldori/common/exception/ErrorCode.kt
+++ b/src/main/kotlin/com/project/byeoldori/common/exception/ErrorCode.kt
@@ -42,6 +42,7 @@ enum class ErrorCode(
     SITE_NOT_FOUND(HttpStatus.NOT_FOUND, "관측지를 찾을 수 없습니다."),
     SAVED_SITE_NOT_FOUND(HttpStatus.NOT_FOUND, "즐겨찾기 목록에 없는 항목입니다."),
     EVENT_NOT_FOUND(HttpStatus.NOT_FOUND, "계획/기록을 찾을 수 없습니다."),
+    EDU_PROGRAM_NOT_FOUND(HttpStatus.NOT_FOUND, "교육 프로그램을 찾을 수 없습니다."),
 
     // 409 Conflict - 리소스 충돌
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "이미 사용 중인 이메일입니다."),

--- a/src/main/kotlin/com/project/byeoldori/education/program/config/MongoAuditingConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/config/MongoAuditingConfig.kt
@@ -1,0 +1,12 @@
+package com.project.byeoldori.education.program.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.config.EnableMongoAuditing
+
+/**
+ * @CreatedDate / @LastModifiedDate (EducationProgram) 감사 필드를 채우기 위한 설정.
+ * 메인 애플리케이션에는 @EnableJpaAuditing 만 있어 Mongo 감사는 별도 활성화가 필요하다.
+ */
+@Configuration
+@EnableMongoAuditing
+class MongoAuditingConfig

--- a/src/main/kotlin/com/project/byeoldori/education/program/controller/EducationProgramController.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/controller/EducationProgramController.kt
@@ -1,0 +1,107 @@
+package com.project.byeoldori.education.program.controller
+
+import com.project.byeoldori.common.web.ApiResponse
+import com.project.byeoldori.community.common.dto.PageResponse
+import com.project.byeoldori.education.program.dto.CreateProgramRequest
+import com.project.byeoldori.education.program.dto.ProgramDetailResponse
+import com.project.byeoldori.education.program.dto.ProgramSummaryResponse
+import com.project.byeoldori.education.program.dto.UpdateProgramRequest
+import com.project.byeoldori.education.program.service.EducationProgramService
+import com.project.byeoldori.user.entity.User
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/education/programs")
+@Tag(name = "EducationProgram", description = "교육 프로그램(인터랙티브 씬) API")
+class EducationProgramController(
+    private val service: EducationProgramService
+) {
+    @PostMapping
+    @Operation(summary = "교육 프로그램 생성", description = "DRAFT 상태로 생성합니다. 작성자=현재 사용자.")
+    fun create(
+        @Valid @RequestBody req: CreateProgramRequest,
+        @RequestAttribute("currentUser") user: User
+    ): ProgramDetailResponse = service.create(user, req)
+
+    @GetMapping
+    @Operation(
+        summary = "교육 프로그램 목록",
+        description = "기본: PUBLISHED 공개 목록. mine=true: 내 전체 상태. pending=true: 검수 큐(PREVIEW, 관리자 전용)."
+    )
+    fun list(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+        @RequestParam(required = false, defaultValue = "false") mine: Boolean,
+        @RequestParam(required = false, defaultValue = "false") pending: Boolean,
+        @RequestAttribute("currentUser") user: User
+    ): PageResponse<ProgramSummaryResponse> {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "updatedAt"))
+        return when {
+            pending -> service.listPending(user, pageable)
+            mine -> service.listMine(user, pageable)
+            else -> service.listPublished(pageable)
+        }
+    }
+
+    @GetMapping("/{id}")
+    @Operation(summary = "교육 프로그램 상세", description = "PUBLISHED 는 누구나, DRAFT/PREVIEW 는 작성자 또는 관리자만.")
+    fun get(
+        @PathVariable id: String,
+        @RequestAttribute("currentUser") user: User
+    ): ProgramDetailResponse = service.get(id, user)
+
+    @PatchMapping("/{id}")
+    @Operation(summary = "교육 프로그램 수정", description = "작성자 본인 & DRAFT/PREVIEW 상태에서만.")
+    fun update(
+        @PathVariable id: String,
+        @Valid @RequestBody req: UpdateProgramRequest,
+        @RequestAttribute("currentUser") user: User
+    ): ProgramDetailResponse = service.update(id, req, user)
+
+    @PostMapping("/{id}/submit")
+    @Operation(summary = "검수 요청", description = "DRAFT → PREVIEW (작성자 본인).")
+    fun submit(
+        @PathVariable id: String,
+        @RequestAttribute("currentUser") user: User
+    ): ProgramDetailResponse = service.submit(id, user)
+
+    @PostMapping("/{id}/publish")
+    @Operation(summary = "발행", description = "PREVIEW → PUBLISHED. moderation.required 가 true 면 관리자만, false 면 작성자도 가능.")
+    fun publish(
+        @PathVariable id: String,
+        @RequestAttribute("currentUser") user: User
+    ): ProgramDetailResponse = service.publish(id, user)
+
+    @PostMapping("/{id}/reject")
+    @Operation(summary = "반려", description = "PREVIEW → DRAFT (관리자 전용).")
+    fun reject(
+        @PathVariable id: String,
+        @RequestAttribute("currentUser") user: User
+    ): ProgramDetailResponse = service.reject(id, user)
+
+    @DeleteMapping("/{id}")
+    @Operation(summary = "교육 프로그램 삭제", description = "작성자 또는 관리자.")
+    fun delete(
+        @PathVariable id: String,
+        @RequestAttribute("currentUser") user: User
+    ): ResponseEntity<ApiResponse<Unit>> {
+        service.delete(id, user)
+        return ResponseEntity.ok(ApiResponse.ok("교육 프로그램이 삭제되었습니다."))
+    }
+
+    @PostMapping("/{id}/view")
+    @Operation(summary = "조회수 증가")
+    fun incrementView(
+        @PathVariable id: String,
+        @RequestAttribute("currentUser") user: User
+    ): ResponseEntity<ApiResponse<Unit>> {
+        service.incrementView(id)
+        return ResponseEntity.ok(ApiResponse.ok())
+    }
+}

--- a/src/main/kotlin/com/project/byeoldori/education/program/domain/EducationProgram.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/domain/EducationProgram.kt
@@ -1,0 +1,48 @@
+package com.project.byeoldori.education.program.domain
+
+import com.project.byeoldori.community.common.domain.EducationDifficulty
+import org.bson.Document
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.mongodb.core.mapping.Document as MongoDocument
+import java.time.LocalDateTime
+
+enum class ProgramStatus { DRAFT, PREVIEW, PUBLISHED }
+
+/**
+ * 교육 프로그램(인터랙티브 씬 JSON) — MongoDB 저장.
+ * steps 는 프론트가 보내는 유연/중첩 구조를 org.bson.Document 로 그대로 보존해 재생용으로 반환한다.
+ * (MySQL 교육 게시글 EducationPost 와는 완전히 별개 도메인)
+ */
+@MongoDocument("education_programs")
+class EducationProgram(
+    @Id
+    var id: String? = null,
+
+    var title: String,
+
+    var subtitle: String? = null,
+
+    var difficulty: EducationDifficulty? = null,
+
+    var targets: List<String> = emptyList(),
+
+    var authorId: Long,
+
+    var authorName: String? = null,
+
+    var status: ProgramStatus = ProgramStatus.DRAFT,
+
+    var schemaVersion: Int = 1,
+
+    var steps: List<Document> = emptyList(),
+
+    var viewCount: Long = 0,
+
+    @CreatedDate
+    var createdAt: LocalDateTime? = null,
+
+    @LastModifiedDate
+    var updatedAt: LocalDateTime? = null
+)

--- a/src/main/kotlin/com/project/byeoldori/education/program/dto/ProgramDtos.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/dto/ProgramDtos.kt
@@ -15,7 +15,8 @@ data class CreateProgramRequest(
     val subtitle: String? = null,
     val difficulty: EducationDifficulty? = null,
     val targets: List<String>? = null,
-    val steps: List<Document>? = null
+    // 프론트 인터랙티브 씬 배열. 요청은 표준 Map 으로 받아(Jackson 안전) 서비스에서 org.bson.Document 로 변환.
+    val steps: List<Map<String, Any?>>? = null
 )
 
 data class UpdateProgramRequest(
@@ -24,7 +25,7 @@ data class UpdateProgramRequest(
     val subtitle: String? = null,
     val difficulty: EducationDifficulty? = null,
     val targets: List<String>? = null,
-    val steps: List<Document>? = null
+    val steps: List<Map<String, Any?>>? = null
 )
 
 data class ProgramSummaryResponse(

--- a/src/main/kotlin/com/project/byeoldori/education/program/dto/ProgramDtos.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/dto/ProgramDtos.kt
@@ -1,0 +1,76 @@
+package com.project.byeoldori.education.program.dto
+
+import com.project.byeoldori.community.common.domain.EducationDifficulty
+import com.project.byeoldori.education.program.domain.EducationProgram
+import com.project.byeoldori.education.program.domain.ProgramStatus
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+import org.bson.Document
+import java.time.LocalDateTime
+
+data class CreateProgramRequest(
+    @field:NotBlank(message = "제목은 필수입니다.")
+    @field:Size(max = 200)
+    val title: String,
+    val subtitle: String? = null,
+    val difficulty: EducationDifficulty? = null,
+    val targets: List<String>? = null,
+    val steps: List<Document>? = null
+)
+
+data class UpdateProgramRequest(
+    @field:Size(max = 200)
+    val title: String? = null,
+    val subtitle: String? = null,
+    val difficulty: EducationDifficulty? = null,
+    val targets: List<String>? = null,
+    val steps: List<Document>? = null
+)
+
+data class ProgramSummaryResponse(
+    val id: String?,
+    val title: String,
+    val difficulty: EducationDifficulty?,
+    val status: ProgramStatus,
+    val authorName: String?,
+    val viewCount: Long,
+    val updatedAt: LocalDateTime?
+) {
+    companion object {
+        fun from(p: EducationProgram) = ProgramSummaryResponse(
+            id = p.id,
+            title = p.title,
+            difficulty = p.difficulty,
+            status = p.status,
+            authorName = p.authorName,
+            viewCount = p.viewCount,
+            updatedAt = p.updatedAt
+        )
+    }
+}
+
+data class ProgramDetailResponse(
+    val id: String?,
+    val title: String,
+    val subtitle: String?,
+    val difficulty: EducationDifficulty?,
+    val schemaVersion: Int,
+    val steps: List<Document>,
+    val status: ProgramStatus,
+    val authorId: Long
+) {
+    companion object {
+        fun from(p: EducationProgram) = ProgramDetailResponse(
+            id = p.id,
+            title = p.title,
+            subtitle = p.subtitle,
+            difficulty = p.difficulty,
+            schemaVersion = p.schemaVersion,
+            steps = p.steps,
+            status = p.status,
+            authorId = p.authorId
+        )
+    }
+}
+
+data class IdStringResponse(val id: String?)

--- a/src/main/kotlin/com/project/byeoldori/education/program/repository/EducationProgramRepository.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/repository/EducationProgramRepository.kt
@@ -1,0 +1,20 @@
+package com.project.byeoldori.education.program.repository
+
+import com.project.byeoldori.education.program.domain.EducationProgram
+import com.project.byeoldori.education.program.domain.ProgramStatus
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.mongodb.repository.MongoRepository
+
+interface EducationProgramRepository : MongoRepository<EducationProgram, String> {
+
+    fun findByStatus(status: ProgramStatus, pageable: Pageable): Page<EducationProgram>
+
+    fun findByAuthorId(authorId: Long, pageable: Pageable): Page<EducationProgram>
+
+    fun findByStatusAndTitleContaining(
+        status: ProgramStatus,
+        title: String,
+        pageable: Pageable
+    ): Page<EducationProgram>
+}

--- a/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
@@ -37,7 +37,7 @@ class EducationProgramService(
             authorId = user.id,
             authorName = user.nickname,
             status = ProgramStatus.DRAFT,
-            steps = req.steps ?: emptyList()
+            steps = req.steps?.map { org.bson.Document(it) } ?: emptyList()
         )
         return ProgramDetailResponse.from(repo.save(program))
     }
@@ -53,7 +53,7 @@ class EducationProgramService(
         req.subtitle?.let { p.subtitle = it }
         req.difficulty?.let { p.difficulty = it }
         req.targets?.let { p.targets = it }
-        req.steps?.let { p.steps = it }
+        req.steps?.let { list -> p.steps = list.map { org.bson.Document(it) } }
 
         return ProgramDetailResponse.from(repo.save(p))
     }

--- a/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
@@ -1,0 +1,144 @@
+package com.project.byeoldori.education.program.service
+
+import com.project.byeoldori.admin.service.SystemConfigService
+import com.project.byeoldori.common.exception.ErrorCode
+import com.project.byeoldori.common.exception.ForbiddenException
+import com.project.byeoldori.common.exception.InvalidInputException
+import com.project.byeoldori.common.exception.NotFoundException
+import com.project.byeoldori.community.common.dto.PageResponse
+import com.project.byeoldori.community.common.dto.toPageResponse
+import com.project.byeoldori.education.program.domain.EducationProgram
+import com.project.byeoldori.education.program.domain.ProgramStatus
+import com.project.byeoldori.education.program.dto.CreateProgramRequest
+import com.project.byeoldori.education.program.dto.ProgramDetailResponse
+import com.project.byeoldori.education.program.dto.ProgramSummaryResponse
+import com.project.byeoldori.education.program.dto.UpdateProgramRequest
+import com.project.byeoldori.education.program.repository.EducationProgramRepository
+import com.project.byeoldori.user.entity.User
+import org.springframework.data.domain.Pageable
+import org.springframework.stereotype.Service
+
+@Service
+class EducationProgramService(
+    private val repo: EducationProgramRepository,
+    private val systemConfigService: SystemConfigService
+) {
+    private fun isAdmin(user: User): Boolean = user.roles.contains("ADMIN")
+
+    private fun findOrThrow(id: String): EducationProgram =
+        repo.findById(id).orElseThrow { NotFoundException(ErrorCode.EDU_PROGRAM_NOT_FOUND) }
+
+    fun create(user: User, req: CreateProgramRequest): ProgramDetailResponse {
+        val program = EducationProgram(
+            title = req.title,
+            subtitle = req.subtitle,
+            difficulty = req.difficulty,
+            targets = req.targets ?: emptyList(),
+            authorId = user.id,
+            authorName = user.nickname,
+            status = ProgramStatus.DRAFT,
+            steps = req.steps ?: emptyList()
+        )
+        return ProgramDetailResponse.from(repo.save(program))
+    }
+
+    fun update(id: String, req: UpdateProgramRequest, user: User): ProgramDetailResponse {
+        val p = findOrThrow(id)
+        if (p.authorId != user.id) throw ForbiddenException()
+        if (p.status != ProgramStatus.DRAFT && p.status != ProgramStatus.PREVIEW) {
+            throw InvalidInputException("발행되었거나 검수 중이 아닌 상태에서만 수정할 수 있습니다.")
+        }
+
+        req.title?.let { p.title = it }
+        req.subtitle?.let { p.subtitle = it }
+        req.difficulty?.let { p.difficulty = it }
+        req.targets?.let { p.targets = it }
+        req.steps?.let { p.steps = it }
+
+        return ProgramDetailResponse.from(repo.save(p))
+    }
+
+    /** DRAFT → PREVIEW (작성자 본인) */
+    fun submit(id: String, user: User): ProgramDetailResponse {
+        val p = findOrThrow(id)
+        if (p.authorId != user.id) throw ForbiddenException()
+        if (p.status != ProgramStatus.DRAFT) {
+            throw InvalidInputException("작성 중(DRAFT) 상태에서만 검수 요청을 할 수 있습니다.")
+        }
+        p.status = ProgramStatus.PREVIEW
+        return ProgramDetailResponse.from(repo.save(p))
+    }
+
+    /**
+     * PREVIEW → PUBLISHED.
+     * moderation.required(전역) 가 true 면 ADMIN 만, false 면 작성자 본인도 발행 가능.
+     */
+    fun publish(id: String, user: User): ProgramDetailResponse {
+        val p = findOrThrow(id)
+        if (p.status != ProgramStatus.PREVIEW) {
+            throw InvalidInputException("검수 대기(PREVIEW) 상태에서만 발행할 수 있습니다.")
+        }
+
+        val moderationRequired = systemConfigService.moderationRequired()
+        val allowed = if (moderationRequired) {
+            isAdmin(user)
+        } else {
+            isAdmin(user) || p.authorId == user.id
+        }
+        if (!allowed) throw ForbiddenException("발행 권한이 없습니다.")
+
+        p.status = ProgramStatus.PUBLISHED
+        return ProgramDetailResponse.from(repo.save(p))
+    }
+
+    /** PREVIEW → DRAFT (ADMIN 반려) */
+    fun reject(id: String, user: User): ProgramDetailResponse {
+        if (!isAdmin(user)) throw ForbiddenException("관리자만 반려할 수 있습니다.")
+        val p = findOrThrow(id)
+        if (p.status != ProgramStatus.PREVIEW) {
+            throw InvalidInputException("검수 대기(PREVIEW) 상태에서만 반려할 수 있습니다.")
+        }
+        p.status = ProgramStatus.DRAFT
+        return ProgramDetailResponse.from(repo.save(p))
+    }
+
+    /** PUBLISHED 전체 공개 목록 */
+    fun listPublished(pageable: Pageable): PageResponse<ProgramSummaryResponse> =
+        repo.findByStatus(ProgramStatus.PUBLISHED, pageable)
+            .map { ProgramSummaryResponse.from(it) }
+            .toPageResponse()
+
+    /** 작성자 본인의 전체 상태 목록 */
+    fun listMine(user: User, pageable: Pageable): PageResponse<ProgramSummaryResponse> =
+        repo.findByAuthorId(user.id, pageable)
+            .map { ProgramSummaryResponse.from(it) }
+            .toPageResponse()
+
+    /** ADMIN 검수 큐(PREVIEW) 목록 */
+    fun listPending(user: User, pageable: Pageable): PageResponse<ProgramSummaryResponse> {
+        if (!isAdmin(user)) throw ForbiddenException("관리자만 검수 큐를 조회할 수 있습니다.")
+        return repo.findByStatus(ProgramStatus.PREVIEW, pageable)
+            .map { ProgramSummaryResponse.from(it) }
+            .toPageResponse()
+    }
+
+    fun get(id: String, user: User): ProgramDetailResponse {
+        val p = findOrThrow(id)
+        if (p.status != ProgramStatus.PUBLISHED && p.authorId != user.id && !isAdmin(user)) {
+            throw ForbiddenException("해당 프로그램을 조회할 권한이 없습니다.")
+        }
+        return ProgramDetailResponse.from(p)
+    }
+
+    fun delete(id: String, user: User) {
+        val p = findOrThrow(id)
+        if (p.authorId != user.id && !isAdmin(user)) throw ForbiddenException()
+        repo.delete(p)
+    }
+
+    fun incrementView(id: String) {
+        val p = findOrThrow(id)
+        p.viewCount += 1
+        repo.save(p)
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,6 +20,10 @@ spring.jpa.properties.hibernate.default_batch_fetch_size=100
 spring.jpa.open-in-view=false
 
 
+# 교육 프로그램(인터랙티브 씬 JSON) 저장소 — MongoDB (교육 게시글은 MySQL 그대로)
+spring.data.mongodb.uri=${MONGO_URI:mongodb://root:root@localhost:27017/byeoldori?authSource=admin}
+spring.data.mongodb.auto-index-creation=true
+
 spring.data.redis.host=${SPRING_REDIS_HOST:localhost}
 spring.data.redis.port=${SPRING_REDIS_PORT:6379}
 


### PR DESCRIPTION
## 개요
교육 게시글(EducationPost, 텍스트)과 **교육 프로그램(인터랙티브 씬 JSON)을 분리** — 게시글은 MySQL 유지, 프로그램은 **MongoDB** 신규 도메인으로.

## 변경
### 인프라 (MongoDB 배선)
- `spring-boot-starter-data-mongodb` 추가
- `spring.data.mongodb.uri=${MONGO_URI}` (교육 게시글 MySQL 무영향)
- `docker-compose.mongo.yml`: 프로덕션 mongo:6.0 오버레이(포트 미노출·내부망·mem_limit·비밀번호 env)
- `deploy.yml`: 블루그린 앞 mongo 선기동 (앱 헬스체크 통과 보장)
- **VM에 mongo 이미 기동 완료**(healthy, 인증 확인)

### 도메인 — 교육 프로그램 (MongoDB)
- `EducationProgram` @Document, `ProgramStatus{DRAFT,PREVIEW,PUBLISHED}` 상태머신
- `/education/programs`: 생성·목록(공개/내것/검수큐)·상세·수정·submit·publish·reject·삭제·조회수
- steps는 `org.bson.Document`로 유연 저장(중첩 씬 보존)

### 시스템 설정 (MySQL) + 어드민
- `SystemConfig`(system_config 테이블) 키-값, `moderation.required` 기본 **ON**
- `/admin/config` GET/PUT — **ADMIN 롤 전용**
- publish 권한: moderation ON이면 ADMIN만, OFF면 작성자도 발행

## 권한 규칙
| 액션 | 권한 |
|---|---|
| create/update/submit | 작성자 본인 |
| publish | moderation ON→ADMIN, OFF→작성자/ADMIN |
| reject/검수큐 | ADMIN |
| get | PUBLISHED 공개, DRAFT/PREVIEW는 작성자/ADMIN |

## 검증
- ✅ `gradlew compileKotlin` 통과
- ✅ 기존 봉투(ApiResponse)·인증(@RequestAttribute currentUser)·예외·enum 패턴 미러링
- ✅ 요청 steps는 Map으로 받아 Jackson 안전, 서비스에서 Document 변환
- 기존 EducationPost(MySQL) 무변경

## 배포 주의
- mongo는 **추가형·빈 상태**(기존 MySQL 데이터 무영향, 마이그레이션 없음)
- 블루그린 헬스게이트로 실패 시 자동 롤백

🤖 Generated with [Claude Code](https://claude.com/claude-code)