### PR TITLE
feat(edu): 교육 프로그램 읽기 공개 (비로그인 감상 허용)

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/project/byeoldori/config/SecurityConfig.kt
@@ -72,6 +72,11 @@ class SecurityConfig(
                     // CORS preflight
                     .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                     .requestMatchers(*PUBLIC_URLS).permitAll()
+                    // 교육 프로그램(천체투영관 감상)은 비로그인도 열람/재생 가능 — 읽기 전용.
+                    // 서비스단에서 PUBLISHED 만 익명에게 노출하고, DRAFT/PREVIEW 는 작성자·관리자만 본다.
+                    // 작성·수정·발행·삭제 등 변경 계열은 아래 anyRequest().authenticated() 로 보호된다.
+                    .requestMatchers(HttpMethod.GET, "/education/programs", "/education/programs/*").permitAll()
+                    .requestMatchers(HttpMethod.POST, "/education/programs/*/view").permitAll()
                     .anyRequest().authenticated()
             }
             .addFilterBefore(rateLimitFilter, UsernamePasswordAuthenticationFilter::class.java)

--- a/src/main/kotlin/com/project/byeoldori/education/program/controller/EducationProgramController.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/controller/EducationProgramController.kt
@@ -1,5 +1,6 @@
 package com.project.byeoldori.education.program.controller
 
+import com.project.byeoldori.common.exception.ForbiddenException
 import com.project.byeoldori.common.web.ApiResponse
 import com.project.byeoldori.community.common.dto.PageResponse
 import com.project.byeoldori.education.program.dto.CreateProgramRequest
@@ -39,21 +40,26 @@ class EducationProgramController(
         @RequestParam(defaultValue = "20") size: Int,
         @RequestParam(required = false, defaultValue = "false") mine: Boolean,
         @RequestParam(required = false, defaultValue = "false") pending: Boolean,
-        @RequestAttribute("currentUser") user: User
+        // 비로그인 공개 목록(PUBLISHED)을 허용하므로 nullable. mine/pending 은 인증 필요.
+        @RequestAttribute(value = "currentUser", required = false) user: User?
     ): PageResponse<ProgramSummaryResponse> {
         val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "updatedAt"))
         return when {
-            pending -> service.listPending(user, pageable)
-            mine -> service.listMine(user, pageable)
+            pending -> service.listPending(requireLogin(user), pageable)
+            mine -> service.listMine(requireLogin(user), pageable)
             else -> service.listPublished(pageable)
         }
     }
+
+    private fun requireLogin(user: User?): User =
+        user ?: throw ForbiddenException("로그인이 필요합니다.")
 
     @GetMapping("/{id}")
     @Operation(summary = "교육 프로그램 상세", description = "PUBLISHED 는 누구나, DRAFT/PREVIEW 는 작성자 또는 관리자만.")
     fun get(
         @PathVariable id: String,
-        @RequestAttribute("currentUser") user: User
+        // PUBLISHED 는 비로그인도 조회 가능하므로 nullable
+        @RequestAttribute(value = "currentUser", required = false) user: User?
     ): ProgramDetailResponse = service.get(id, user)
 
     @PatchMapping("/{id}")
@@ -99,7 +105,8 @@ class EducationProgramController(
     @Operation(summary = "조회수 증가")
     fun incrementView(
         @PathVariable id: String,
-        @RequestAttribute("currentUser") user: User
+        @Suppress("UNUSED_PARAMETER")
+        @RequestAttribute(value = "currentUser", required = false) user: User?
     ): ResponseEntity<ApiResponse<Unit>> {
         service.incrementView(id)
         return ResponseEntity.ok(ApiResponse.ok())

--- a/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
@@ -122,10 +122,12 @@ class EducationProgramService(
             .toPageResponse()
     }
 
-    fun get(id: String, user: User): ProgramDetailResponse {
+    /** PUBLISHED 는 비로그인 포함 누구나. DRAFT/PREVIEW 는 작성자 또는 관리자만. */
+    fun get(id: String, user: User?): ProgramDetailResponse {
         val p = findOrThrow(id)
-        if (p.status != ProgramStatus.PUBLISHED && p.authorId != user.id && !isAdmin(user)) {
-            throw ForbiddenException("해당 프로그램을 조회할 권한이 없습니다.")
+        if (p.status != ProgramStatus.PUBLISHED) {
+            val allowed = user != null && (p.authorId == user.id || isAdmin(user))
+            if (!allowed) throw ForbiddenException("해당 프로그램을 조회할 권한이 없습니다.")
         }
         return ProgramDetailResponse.from(p)
     }


### PR DESCRIPTION
## 개요
천체투영관식 교육 프로그램을 **비로그인 방문자도 감상**할 수 있도록 읽기 전용 공개. starmap이 `(public)` 라우트인데 프로그램 조회가 인증 필요라 익명 방문자에게 목록이 비어 보이던 문제 해결. SEO에도 유리.

## 변경 (보안 정책)
| 엔드포인트 | 변경 |
|---|---|
| `GET /education/programs` | permitAll (공개 목록 = PUBLISHED만) |
| `GET /education/programs/{id}` | permitAll (PUBLISHED만 익명 노출) |
| `POST /education/programs/{id}/view` | permitAll (조회수) |
| 생성·수정·submit·publish·reject·삭제 | **인증 유지** (변경 없음) |
| `?mine=true`, `?pending=true` | 비로그인 시 403 |

## 안전성 근거
- `JwtAuthenticationFilter`는 **토큰이 없으면 검증을 건너뛰고 통과**시키고, 유효 토큰이면 경로와 무관하게 `currentUser`를 세팅한다. 따라서 공개 GET에서도 로그인 사용자는 그대로 식별되어 본인 DRAFT/PREVIEW 조회가 유지된다.
- 컨트롤러의 `currentUser`를 `required=false` nullable로 바꿔 익명 요청에서 속성 누락으로 터지지 않게 처리.
- 서비스 `get()`: PUBLISHED가 아니면 `user != null && (작성자 || ADMIN)` 일 때만 허용 → **미발행 콘텐츠는 익명에게 절대 노출되지 않음**.

## 검증
- ✅ `gradlew compileKotlin` 통과
- 배포 후 확인 예정: 익명 `GET /education/programs` → PUBLISHED 목록(orion-101, ursa-major) 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)