### PR TITLE
feat(edu): 교육 게시글에 프로그램 연결 필드(programId) 추가

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/community/post/domain/EducationPost.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/post/domain/EducationPost.kt
@@ -30,6 +30,12 @@ class EducationPost(
     @Column(name = "content_url", length = 1024)
     var contentUrl: String? = null,
 
+    // 연결된 인터랙티브 교육 프로그램(MongoDB education_programs)의 id.
+    // 게시글은 MySQL, 프로그램(씬 JSON)은 MongoDB 로 분리돼 있어 id 로만 잇는다.
+    // null 이면 재생할 프로그램이 없는 일반 교육 글.
+    @Column(name = "program_id", length = 64)
+    var programId: String? = null,
+
     @Column(name = "average_score", nullable = false)
     var averageScore: Double = 0.0, // 평균 평점
 

--- a/src/main/kotlin/com/project/byeoldori/community/post/dto/PostDtos.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/post/dto/PostDtos.kt
@@ -24,7 +24,8 @@ data class EducationRequestDto(
     val targets: List<String>? = null,
     val tags: String? = null,
     val status: EducationStatus? = null, // null → DRAFT
-    val contentUrl: String? = null // 생성시 입력하지 않음
+    val contentUrl: String? = null, // 생성시 입력하지 않음
+    val programId: String? = null // 연결할 인터랙티브 프로그램(MongoDB) id
 )
 
 data class EducationResponseDto(
@@ -33,7 +34,8 @@ data class EducationResponseDto(
     val tags: String? = null,
     val status: EducationStatus? = null,
     val averageScore: Double = 0.0,
-    val contentUrl: String? = null
+    val contentUrl: String? = null,
+    val programId: String? = null
 ) {
     companion object {
         fun from(educationPost: EducationPost,targets: List<String>) = EducationResponseDto(
@@ -42,7 +44,8 @@ data class EducationResponseDto(
             tags = educationPost.tags,
             status = educationPost.status,
             averageScore = educationPost.averageScore,
-            contentUrl = educationPost.contentUrl
+            contentUrl = educationPost.contentUrl,
+            programId = educationPost.programId
         )
     }
 }

--- a/src/main/kotlin/com/project/byeoldori/community/post/service/PostService.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/post/service/PostService.kt
@@ -76,6 +76,7 @@ class PostService(
                     difficulty = d.difficulty,
                     tags = d.tags,
                     status = d.status ?: EducationStatus.DRAFT,
+                    programId = d.programId,
                 )
 
                 d.contentUrl?.trim()?.let { url ->
@@ -207,7 +208,8 @@ class PostService(
                 .filter { it.isNotBlank() }
             EducationResponseDto(
                 difficulty = ep.difficulty,
-                targets = targets, tags = ep.tags, status = ep.status, averageScore = ep.averageScore, contentUrl = ep.contentUrl
+                targets = targets, tags = ep.tags, status = ep.status, averageScore = ep.averageScore,
+                contentUrl = ep.contentUrl, programId = ep.programId
             )
         }
 
@@ -312,6 +314,11 @@ class PostService(
         educationDto.difficulty?.let { educationPost.difficulty = it }
         educationDto.tags?.let { educationPost.tags = it }
         educationDto.status?.let { educationPost.status = it }
+
+        // 연결 프로그램 id (빈 문자열로 오면 연결 해제)
+        educationDto.programId?.let { raw ->
+            educationPost.programId = raw.trim().ifEmpty { null }
+        }
 
         // JSON URL 세팅 (null/미포함이면 무시)
         if (educationDto.contentUrl != null) {


### PR DESCRIPTION
커뮤니티의 '교육 프로그램 작성' 을 실제 저작 기능으로 만들기 위한 첫 조각입니다.

## 배경
교육 게시글은 MySQL, 인터랙티브 프로그램(씬 JSON)은 MongoDB 로 분리돼 있는데 서로를 모르는 상태였습니다. 작성 화면에서 프로그램을 만들면 Mongo 에 저장되지만, 그 글에서 다시 찾아갈 방법이 없었습니다.

## 변경
- `EducationPost.programId` (varchar 64, nullable) 추가 — null 이면 재생할 프로그램이 없는 일반 교육 글
- `EducationRequestDto` / `EducationResponseDto` 반영
- 생성·수정 경로 모두 처리 (수정 시 빈 문자열로 오면 연결 해제)

## 효과
게시글 상세에서 **▶ 실행하기** → `/starmap?programId=xxx` 로 넘길 수 있습니다. starmap 은 이미 `?programId=` 를 Mongo id 로 로드하도록 배선돼 있어 프론트 추가 작업 없이 동작합니다.

ddl-auto=update 로 컬럼이 자동 추가되며, 기존 행은 null 이라 영향 없습니다.

✅ `gradlew compileKotlin` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)