### PR TITLE
fix(edu): 조회수 증가가 저작 내용을 덮어쓰던 문제 외 P0 3건

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/community/post/service/PostService.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/post/service/PostService.kt
@@ -12,6 +12,8 @@ import com.project.byeoldori.observationsites.repository.ObservationSiteReposito
 import com.project.byeoldori.star.service.ContentTargetService
 import com.project.byeoldori.star.entity.ContentType
 import com.project.byeoldori.user.entity.User
+import com.project.byeoldori.education.program.domain.ProgramStatus
+import com.project.byeoldori.education.program.repository.EducationProgramRepository
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.data.domain.*
 import org.springframework.stereotype.Service
@@ -33,7 +35,27 @@ class PostService(
     private val educationRatingRepo: EducationRatingRepository,
     private val storage: StorageService,
     private val contentTargetService: ContentTargetService,
+    private val educationProgramRepository: EducationProgramRepository,
 ) {
+
+    /**
+     * 게시글에 연결하려는 교육 프로그램을 검증한다.
+     *
+     * 검증이 없으면 저작자가 임시저장(DRAFT)만 한 프로그램을 글에 연결해 게시할 수 있는데,
+     * 미발행 프로그램은 작성자·관리자 외에는 조회가 403 이라 방문자에겐 '실행 버튼이
+     * 아무 반응 없는' 상태가 된다. 작성자 본인 화면에서는 정상 동작해 발견되지도 않는다.
+     * 삭제된 프로그램 id 를 남겨두는 고아 참조도 여기서 막는다.
+     */
+    private fun validateProgramId(programId: String) {
+        val program = educationProgramRepository.findById(programId).orElseThrow {
+            InvalidInputException("연결하려는 교육 프로그램을 찾을 수 없습니다.")
+        }
+        if (program.status != ProgramStatus.PUBLISHED) {
+            throw InvalidInputException(
+                "발행되지 않은 교육 프로그램은 게시글에 연결할 수 없습니다. 프로그램을 먼저 발행해주세요."
+            )
+        }
+    }
 
     @Value("\${community.home.item-count:20}")
     private val homeItemCount: Int = 20
@@ -71,12 +93,13 @@ class PostService(
             PostType.EDUCATION -> {
                 val d = req.education ?: EducationRequestDto()
 
+                d.programId?.takeIf { it.isNotBlank() }?.let { validateProgramId(it) }
                 val ep = EducationPost(
                     post = post,
                     difficulty = d.difficulty,
                     tags = d.tags,
                     status = d.status ?: EducationStatus.DRAFT,
-                    programId = d.programId,
+                    programId = d.programId?.takeIf { it.isNotBlank() },
                 )
 
                 d.contentUrl?.trim()?.let { url ->
@@ -317,7 +340,13 @@ class PostService(
 
         // 연결 프로그램 id (빈 문자열로 오면 연결 해제)
         educationDto.programId?.let { raw ->
-            educationPost.programId = raw.trim().ifEmpty { null }
+            val trimmed = raw.trim()
+            if (trimmed.isEmpty()) {
+                educationPost.programId = null
+            } else {
+                validateProgramId(trimmed)
+                educationPost.programId = trimmed
+            }
         }
 
         // JSON URL 세팅 (null/미포함이면 무시)

--- a/src/main/kotlin/com/project/byeoldori/education/program/controller/EducationProgramController.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/controller/EducationProgramController.kt
@@ -43,7 +43,11 @@ class EducationProgramController(
         // 비로그인 공개 목록(PUBLISHED)을 허용하므로 nullable. mine/pending 은 인증 필요.
         @RequestAttribute(value = "currentUser", required = false) user: User?
     ): PageResponse<ProgramSummaryResponse> {
-        val pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "updatedAt"))
+        // 비로그인도 호출 가능한 공개 API 라 상한이 없으면 ?size=1000000 한 방으로
+        // 전체 프로그램(steps 포함)을 메모리에 올리게 된다. 반드시 제한한다.
+        val safePage = page.coerceAtLeast(0)
+        val safeSize = size.coerceIn(1, 50)
+        val pageable = PageRequest.of(safePage, safeSize, Sort.by(Sort.Direction.DESC, "updatedAt"))
         return when {
             pending -> service.listPending(requireLogin(user), pageable)
             mine -> service.listMine(requireLogin(user), pageable)

--- a/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
@@ -16,12 +16,17 @@ import com.project.byeoldori.education.program.dto.UpdateProgramRequest
 import com.project.byeoldori.education.program.repository.EducationProgramRepository
 import com.project.byeoldori.user.entity.User
 import org.springframework.data.domain.Pageable
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.mongodb.core.query.Criteria
+import org.springframework.data.mongodb.core.query.Query
+import org.springframework.data.mongodb.core.query.Update
 import org.springframework.stereotype.Service
 
 @Service
 class EducationProgramService(
     private val repo: EducationProgramRepository,
-    private val systemConfigService: SystemConfigService
+    private val systemConfigService: SystemConfigService,
+    private val mongoTemplate: MongoTemplate
 ) {
     private fun isAdmin(user: User): Boolean = user.roles.contains("ADMIN")
 
@@ -138,9 +143,24 @@ class EducationProgramService(
         repo.delete(p)
     }
 
+    /**
+     * 조회수 증가 — 반드시 원자적 부분 갱신으로 처리한다.
+     *
+     * 예전에는 문서를 통째로 읽어 save() 했는데, 이 API 는 비로그인 포함 누구나
+     * 재생할 때마다 호출된다. 저작자가 편집 중이면 (읽기 → 저작자 저장 → 여기서 save)
+     * 순서로 방금 저장한 steps 가 통째로 덮어써져 조용히 사라졌다.
+     * $inc 만 보내면 다른 필드는 건드리지 않는다.
+     *
+     * PUBLISHED 만 카운트해 미발행 프로그램의 조회수 조작과 불필요한 쓰기를 막는다.
+     */
     fun incrementView(id: String) {
-        val p = findOrThrow(id)
-        p.viewCount += 1
-        repo.save(p)
+        mongoTemplate.updateFirst(
+            Query(
+                Criteria.where("_id").`is`(id)
+                    .and("status").`is`(ProgramStatus.PUBLISHED.name)
+            ),
+            Update().inc("viewCount", 1),
+            EducationProgram::class.java
+        )
     }
 }


### PR DESCRIPTION
다차원 감사(40건 발견·35건 반증 검증 통과)에서 나온 P0 중 백엔드 몫입니다.

## 1. `incrementView` 데이터 유실 — 가장 심각
```kotlin
// before: 문서를 통째로 읽어 저장
val p = findOrThrow(id); p.viewCount += 1; repo.save(p)
```
이 API 는 **비로그인 포함 누구나 재생할 때마다** 호출됩니다. 저작자가 편집 중이면 (여기서 읽기 → 저작자가 저장 → 여기서 save) 순서로 **방금 저장한 steps 가 통째로 덮어써지고**, 저작자에게는 성공 토스트까지 떠서 유실을 알 수 없습니다.

→ `MongoTemplate` 의 `$inc` 부분 갱신으로 변경. 다른 필드는 건드리지 않습니다. 조건에 `status == PUBLISHED` 를 넣어 미발행 프로그램 조회수 조작과 불필요한 쓰기도 막았습니다.

## 2. 공개 목록 API page/size 무제한
`GET /education/programs` 는 최근 비로그인 공개로 전환했는데 상한이 없어 `?size=1000000` 한 번으로 전체 프로그램을 `steps` 까지 메모리에 올릴 수 있었습니다. → `size` 1~50, `page` ≥ 0 제한.

## 3. 게시글에 미발행 프로그램 연결 (조용한 실패)
`programId` 를 검증 없이 저장하고 있었습니다. 저작자가 임시저장(DRAFT)만 한 프로그램을 글에 연결하면, 백엔드 `get()` 이 미발행에 403 을 주므로 **방문자에게는 실행 버튼이 영구 무반응**입니다. 작성자 본인 화면에서는 정상 동작해 발견되지 않는 비대칭 버그입니다.

→ 생성·수정 양쪽에서 프로그램 존재 + `PUBLISHED` 검증 후 400 반환. 삭제된 프로그램을 가리키는 고아 참조도 함께 차단됩니다.

✅ `gradlew compileKotlin` 통과

## 남은 연계 작업(프론트)
- 저작 화면에 **발행 버튼** 추가 — 현재 코드에 PUBLISHED 로 갈 경로 자체가 없음
- `loadProgramById` 실패 시 403/404 구분 안내
- 스텝 전환 시 타이머·나레이션 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)