### PR TITLE
fix(edu): 교육 프로그램 입력 크기 검증 (P1)

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/education/program/dto/ProgramDtos.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/dto/ProgramDtos.kt
@@ -12,19 +12,25 @@ data class CreateProgramRequest(
     @field:NotBlank(message = "제목은 필수입니다.")
     @field:Size(max = 200)
     val title: String,
+    @field:Size(max = 300, message = "부제는 300자를 넘을 수 없습니다.")
     val subtitle: String? = null,
     val difficulty: EducationDifficulty? = null,
+    @field:Size(max = 30, message = "대상 천체는 최대 30개입니다.")
     val targets: List<String>? = null,
     // 프론트 인터랙티브 씬 배열. 요청은 표준 Map 으로 받아(Jackson 안전) 서비스에서 org.bson.Document 로 변환.
+    @field:Size(max = 500, message = "스텝은 최대 500개입니다.")
     val steps: List<Map<String, Any?>>? = null
 )
 
 data class UpdateProgramRequest(
     @field:Size(max = 200)
     val title: String? = null,
+    @field:Size(max = 300, message = "부제는 300자를 넘을 수 없습니다.")
     val subtitle: String? = null,
     val difficulty: EducationDifficulty? = null,
+    @field:Size(max = 30, message = "대상 천체는 최대 30개입니다.")
     val targets: List<String>? = null,
+    @field:Size(max = 500, message = "스텝은 최대 500개입니다.")
     val steps: List<Map<String, Any?>>? = null
 )
 

--- a/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
+++ b/src/main/kotlin/com/project/byeoldori/education/program/service/EducationProgramService.kt
@@ -28,10 +28,29 @@ class EducationProgramService(
     private val systemConfigService: SystemConfigService,
     private val mongoTemplate: MongoTemplate
 ) {
+    companion object {
+        private const val MAX_STEPS_BYTES = 512 * 1024 // 512KB
+    }
+
     private fun isAdmin(user: User): Boolean = user.roles.contains("ADMIN")
 
     private fun findOrThrow(id: String): EducationProgram =
         repo.findById(id).orElseThrow { NotFoundException(ErrorCode.EDU_PROGRAM_NOT_FOUND) }
+
+    /**
+     * steps 를 org.bson.Document 로 변환하며 전체 직렬화 크기를 제한한다.
+     * @Size(max=500) 은 스텝 "개수"만 막으므로, 스텝 하나에 거대한 text/base64 이미지를
+     * 넣는 식의 남용은 막지 못한다. 문서 하나가 Mongo 를 잠식하지 않도록 512KB 상한을 둔다.
+     */
+    private fun toSteps(raw: List<Map<String, Any?>>?): List<org.bson.Document> {
+        if (raw.isNullOrEmpty()) return emptyList()
+        val docs = raw.map { org.bson.Document(it) }
+        val bytes = org.bson.Document("s", docs).toJson().toByteArray(Charsets.UTF_8).size
+        if (bytes > MAX_STEPS_BYTES) {
+            throw InvalidInputException("프로그램 내용이 너무 큽니다(최대 512KB). 이미지 URL 은 링크로 넣어주세요.")
+        }
+        return docs
+    }
 
     fun create(user: User, req: CreateProgramRequest): ProgramDetailResponse {
         val program = EducationProgram(
@@ -42,7 +61,7 @@ class EducationProgramService(
             authorId = user.id,
             authorName = user.nickname,
             status = ProgramStatus.DRAFT,
-            steps = req.steps?.map { org.bson.Document(it) } ?: emptyList()
+            steps = toSteps(req.steps)
         )
         return ProgramDetailResponse.from(repo.save(program))
     }
@@ -58,7 +77,7 @@ class EducationProgramService(
         req.subtitle?.let { p.subtitle = it }
         req.difficulty?.let { p.difficulty = it }
         req.targets?.let { p.targets = it }
-        req.steps?.let { list -> p.steps = list.map { org.bson.Document(it) } }
+        req.steps?.let { p.steps = toSteps(it) }
 
         return ProgramDetailResponse.from(repo.save(p))
     }


### PR DESCRIPTION
감사 P1-5. 로그인만 하면 무제한 입력으로 MongoDB 를 잠식할 수 있던 경로를 막습니다(P0-2 조회수 유실 수정 이후 남은 마지막 증폭 경로).

- `subtitle` 300자 / `targets` 30개 / `steps` 500개 — `@Size`, 400 반환
- **steps 직렬화 512KB 상한**: `@Size` 는 스텝 개수만 막으므로, 스텝 하나에 거대한 text·base64 이미지를 넣는 남용은 서비스의 Document 변환 시점에서 차단(이미지는 URL 링크로 넣도록 안내 메시지)

✅ `gradlew compileKotlin` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)