### PR TITLE
feat(files): 게시글 첨부용 일반 파일 업로드 엔드포인트

### DIFF
--- a/src/main/kotlin/com/project/byeoldori/community/common/controller/FileController.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/common/controller/FileController.kt
@@ -29,4 +29,12 @@ class FileController(
         val resp = FileUploadResponse(url, file.originalFilename ?: "", file.size, file.contentType)
         return ApiResponse.ok(resp)
     }
+
+    @PostMapping("/upload", consumes = ["multipart/form-data"])
+    @Operation(summary = "일반 파일 업로드", description = "게시글 첨부용 문서/파일 업로드 후 공개 URL 반환(확장자 화이트리스트·20MB 제한)")
+    fun uploadFile(@RequestPart("file") file: MultipartFile): ApiResponse<FileUploadResponse> {
+        val url = storage.storeFile(file)
+        val resp = FileUploadResponse(url, file.originalFilename ?: "", file.size, file.contentType)
+        return ApiResponse.ok(resp)
+    }
 }

--- a/src/main/kotlin/com/project/byeoldori/community/common/service/AttachmentPolicy.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/common/service/AttachmentPolicy.kt
@@ -1,0 +1,40 @@
+package com.project.byeoldori.community.common.service
+
+import com.project.byeoldori.common.exception.InvalidInputException
+import org.springframework.web.multipart.MultipartFile
+
+/**
+ * 게시글 첨부용 일반 파일 업로드 정책.
+ *
+ * 이미지 업로드(storeImage)는 픽셀 폭탄까지 방어하는 별도 경로이고, 여기는 문서·압축 등
+ * "그대로 보관해 다운로드시키는" 첨부를 다룬다. 임의 실행 파일 업로드를 막기 위해
+ * 확장자 화이트리스트 + 크기 상한을 강제한다. Content-Type 은 조작이 쉬우므로 확장자를 신뢰선으로 둔다.
+ */
+object AttachmentPolicy {
+    const val MAX_BYTES: Long = 20L * 1024 * 1024 // 20MB
+
+    // 실행/스크립트 계열은 제외. 필요 시 확장.
+    val ALLOWED_EXT: Set<String> = setOf(
+        // 이미지
+        "jpg", "jpeg", "png", "gif", "webp", "svg",
+        // 문서
+        "pdf", "txt", "csv", "md",
+        "doc", "docx", "ppt", "pptx", "xls", "xlsx", "hwp", "hwpx",
+        // 압축
+        "zip",
+    )
+
+    /** 검증 후 저장에 쓸 안전한 확장자(소문자)를 반환한다. */
+    fun validateAndExt(file: MultipartFile): String {
+        if (file.isEmpty) throw InvalidInputException("업로드할 파일이 비어있습니다.")
+        if (file.size > MAX_BYTES) {
+            throw InvalidInputException("파일이 너무 큽니다. (최대 20MB)")
+        }
+        val name = file.originalFilename ?: ""
+        val ext = name.substringAfterLast('.', "").lowercase()
+        if (ext.isBlank() || ext !in ALLOWED_EXT) {
+            throw InvalidInputException("지원하지 않는 파일 형식입니다: ${if (ext.isBlank()) "(확장자 없음)" else ext}")
+        }
+        return ext
+    }
+}

--- a/src/main/kotlin/com/project/byeoldori/community/common/service/GcsStorageService.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/common/service/GcsStorageService.kt
@@ -98,6 +98,23 @@ class GcsStorageService(
         }
     }
 
+    override fun storeFile(file: MultipartFile): String {
+        val ext = AttachmentPolicy.validateAndExt(file)
+
+        val today = LocalDate.now()
+        val datePath = "%d/%02d/%02d".format(today.year, today.monthValue, today.dayOfMonth)
+        val filename = UUID.randomUUID().toString().replace("-", "") + "." + ext
+        val objectName = "files/$datePath/$filename"
+
+        val builder = BlobInfo.newBuilder(bucketName, objectName)
+        file.contentType?.let { builder.setContentType(it) }
+        val blobInfo = builder.build()
+
+        file.inputStream.use { input -> storage.create(blobInfo, input.readBytes()) }
+
+        return "${publicBaseUrl.trimEnd('/')}/$objectName"
+    }
+
     override fun storeJson(file: MultipartFile): String {
         if (file.isEmpty) throw InvalidInputException("빈 파일입니다.")
         val ct = (file.contentType ?: "").lowercase()

--- a/src/main/kotlin/com/project/byeoldori/community/common/service/LocalStorageService.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/common/service/LocalStorageService.kt
@@ -112,6 +112,31 @@ class LocalStorageService(
         }
     }
 
+    override fun storeFile(file: MultipartFile): String {
+        val ext = AttachmentPolicy.validateAndExt(file)
+
+        val today = LocalDate.now()
+        val dir = Paths.get(
+            baseDir, "files",
+            today.year.toString(),
+            "%02d".format(today.monthValue),
+            "%02d".format(today.dayOfMonth)
+        )
+        Files.createDirectories(dir)
+
+        val filename = UUID.randomUUID().toString().replace("-", "") + "." + ext
+        val target = dir.resolve(filename)
+        file.inputStream.use { Files.copy(it, target, StandardCopyOption.REPLACE_EXISTING) }
+
+        return listOf(
+            publicBaseUrl.trimEnd('/'), "files",
+            today.year.toString(),
+            "%02d".format(today.monthValue),
+            "%02d".format(today.dayOfMonth),
+            filename
+        ).joinToString("/")
+    }
+
     override fun storeJson(file: MultipartFile): String {
         if (file.isEmpty) throw InvalidInputException("빈 파일입니다.")
         val ct = (file.contentType ?: "").lowercase()

--- a/src/main/kotlin/com/project/byeoldori/community/common/service/StorageService.kt
+++ b/src/main/kotlin/com/project/byeoldori/community/common/service/StorageService.kt
@@ -8,4 +8,7 @@ interface StorageService {
 
     // 교육 JSON 업로드 (공개 URL 반환)
     fun storeJson(file: MultipartFile): String
+
+    // 게시글 첨부용 일반 파일 업로드 (문서 등, 공개 URL 반환)
+    fun storeFile(file: MultipartFile): String
 }


### PR DESCRIPTION
Lexical 리치 에디터 첨부 기능의 백엔드 의존성입니다. 기존엔 `/files/image`(이미지)·`/files/json`(교육 콘텐츠)만 있어 일반 문서 첨부가 불가능했습니다.

## 추가
- `POST /files/upload` — 게시글 첨부용 일반 파일
- `AttachmentPolicy`: **확장자 화이트리스트**(이미지·pdf·office·hwp·txt·csv·zip 등) + **20MB 상한**. Content-Type 은 조작이 쉬워 확장자를 신뢰선으로 검증하고, 실행/스크립트 계열은 차단.
- `StorageService.storeFile` — Local·GCS 양쪽 구현(`storeJson` 패턴 미러링, `files/날짜/uuid.ext`)
- 인증 필요(PUBLIC_URLS 아님) — 로그인 사용자만 업로드

## 참고
프론트 `FileUploadResponse` 타입이 `{imageUrl}` 하나만 선언돼 있는데 백엔드는 `{url, filename, size, contentType}` 4필드를 반환하는 기존 불일치가 있습니다 — 프론트 Lexical 작업에서 함께 교정 예정.

✅ `gradlew compileKotlin` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)